### PR TITLE
Add TypeScript GitHub App MCP refactor package

### DIFF
--- a/.pi/subagent-schedules/019f281f-6072-718c-a24a-3a19b05cfe40.json
+++ b/.pi/subagent-schedules/019f281f-6072-718c-a24a-3a19b05cfe40.json
@@ -17,10 +17,10 @@
       "isolation": "worktree",
       "enabled": true,
       "createdAt": "2026-07-04T07:55:44.641Z",
-      "runCount": 5,
+      "runCount": 6,
       "lastStatus": "running",
-      "lastRun": "2026-07-04T08:12:06.012Z",
-      "nextRun": "2026-07-04T08:11:03.118Z"
+      "lastRun": "2026-07-04T08:15:59.940Z",
+      "nextRun": "2026-07-04T08:15:06.012Z"
     }
   ]
 }

--- a/.pi/subagent-schedules/019f281f-6072-718c-a24a-3a19b05cfe40.json
+++ b/.pi/subagent-schedules/019f281f-6072-718c-a24a-3a19b05cfe40.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "jobs": [
+    {
+      "id": "O2u61-4j3A",
+      "name": "PR maintainer cycle",
+      "description": "PR maintainer cycle",
+      "schedule": "3m",
+      "scheduleType": "interval",
+      "intervalMs": 180000,
+      "subagent_type": "pr_monkey",
+      "prompt": "You are running ONE cycle of the PR-maintainer loop for PR heruujoko/github-review-mcp#3.\n\nRepository: /Users/herujokoutomo/Code/github-review-mcp\nState file: .pr-maintainer-loop/heruujoko__github-review-mcp__3.json\nPR URL: https://github.com/heruujoko/github-review-mcp/pull/3\n\nImportant current context from preflight:\n- gh auth is working for heruujoko/github-review-mcp.\n- PR is OPEN and mergeable.\n- Inline review comments currently include at least two actionable Codex comments:\n  1. refactor/src/services/github.ts line 179: paginate PR file, commit, and review listings; get_pr_details and analysis tools currently only see first page.\n  2. refactor/src/services/analysis.ts line 496: SECURITY_PATTERNS regexes use global flag; RegExp.test mutates lastIndex and can skip matches across files. Reset lastIndex before each test or remove global flags.\n- One top-level Codex review comment is informational/generic and should be classified as informational-only unless new actionable content appears.\n\nRun this cycle, in strict order:\n\n1. Verify `gh` is installed and `gh auth status` succeeds. On failure: stop the cycle, log it in history, do NOT touch quietCycles.\n\n2. Enumerate ALL feedback threads — BOTH:\n   - inline review comments: `gh api repos/heruujoko/github-review-mcp/pulls/3/comments --paginate`\n   - top-level reviews + issue comments: `gh pr view 3 --repo heruujoko/github-review-mcp --json reviews,comments`\n   Record for each: id, file:line (inline), author, author_type, body summary, commit_id.\n\n3. Classify EVERY thread:\n   - actionable | already-applied | outdated/invalid | informational-only\n   A bot/system author is NOT a reason to skip a thread.\n\n4. Compute NEW actionable = actionable threads whose id is NOT in handledThreadIds AND NOT in inProgressThreadIds from the state file.\n\n5. If NEW actionable exists:\n   a. quietCycles = 0\n   b. Select ONE item only. Prefer the smallest/safest fix if there are multiple.\n   c. Make the minimal code fix on branch refactor/mcp-review-typescript, run relevant validation, commit and push the fix.\n   d. Reply in the SAME review thread via GitHub API, and reference the fix commit SHA in the reply. Resolve where appropriate if supported.\n   e. Move that thread id to handledThreadIds after fix+reply are complete; if fix is pending, use inProgressThreadIds.\n\n6. If NO NEW actionable:\n   a. quietCycles += 1\n   b. For any inProgressThreadIds whose fix+reply have now landed, move them to handledThreadIds.\n\n7. Reflect: re-run thread enumeration and confirm every actionable thread is in terminal state (replied+resolved, OR explicitly still-open with a reason).\n\n8. Update state file atomically: lastCycleAt, quietCycles, handledThreadIds, inProgressThreadIds, cycleCount+1, append a history entry { cycle, ts, newActionable, quietCycles, note }.\n\n9. Checkpoint the loop with loop_designer action checkpoint if available; otherwise record the checkpoint in your final summary.\n\nSTOP RULES:\n- quietCycles >= 3 → PR calm.\n- PR merged or closed.\n- gh auth broken 2 cycles in a row.\n- cycleCount >= 20.\n- Scope drift / destructive command / secret access.\n\nNEVER merge the PR. NEVER silently resolve a thread without a reply referencing the fix SHA. NEVER report quiet while any non-informational thread is unclassified. NEVER re-handle a thread id already in handledThreadIds.\n\nReturn concise final summary: cycle number, selected item, commit SHA if any, pushed?, replied thread id?, quietCycles, remaining actionable items.",
+      "model": "",
+      "thinking": "low",
+      "max_turns": 30,
+      "isolated": false,
+      "isolation": "worktree",
+      "enabled": true,
+      "createdAt": "2026-07-04T07:55:44.641Z",
+      "runCount": 5,
+      "lastStatus": "running",
+      "lastRun": "2026-07-04T08:12:06.012Z",
+      "nextRun": "2026-07-04T08:11:03.118Z"
+    }
+  ]
+}

--- a/.pr-maintainer-loop/heruujoko__github-review-mcp__3.json
+++ b/.pr-maintainer-loop/heruujoko__github-review-mcp__3.json
@@ -1,0 +1,55 @@
+{
+  "pr": {
+    "owner": "heruujoko",
+    "repo": "github-review-mcp",
+    "number": 3,
+    "url": "https://github.com/heruujoko/github-review-mcp/pull/3"
+  },
+  "baseSha": "989816fb2e5392d227b6fdc2ad1c3f13b76bc775",
+  "handledThreadIds": [
+    "3522797510",
+    "3522797511",
+    "3522830247"
+  ],
+  "inProgressThreadIds": [],
+  "quietCycles": 0,
+  "cycleCount": 4,
+  "lastCycleAt": "2026-07-04T08:11:26.000Z",
+  "history": [
+    {
+      "cycle": 0,
+      "ts": "2026-07-04T15:45:00.000Z",
+      "newActionable": 0,
+      "quietCycles": 0,
+      "note": "Loop seeded. Pre-existing inline review comments, top-level reviews, and issue comments inventory was empty."
+    },
+    {
+      "cycle": 1,
+      "ts": "2026-07-04T08:00:10.560397Z",
+      "newActionable": 2,
+      "quietCycles": 0,
+      "note": "Handled inline thread 3522797511: reset SECURITY_PATTERNS regex lastIndex before each test; committed/pushed 8e93521cacfab62d5446dc225c2c2748c6ce72f6 and replied in-thread. Remaining actionable: 3522797510 pagination."
+    },
+    {
+      "cycle": 2,
+      "ts": "2026-07-04T08:04:45.942542Z",
+      "newActionable": 1,
+      "quietCycles": 0,
+      "note": "Handled inline thread 3522797510: paginated PR files, commits, and reviews via Octokit paginate; committed/pushed 531d7d70889c13faa1282583af8a80b4beca9fb2 and replied in-thread. Remaining actionable: none known; prior thread 3522797511 already handled."
+    },
+    {
+      "cycle": 3,
+      "ts": "2026-07-04T08:05:29.593272Z",
+      "newActionable": 0,
+      "quietCycles": 1,
+      "note": "Enumerated inline review comments, top-level reviews, and issue comments. No new actionable threads: Codex pagination thread 3522797510 and regex lastIndex thread 3522797511 were already handled with in-thread replies; top-level Codex review remains informational-only."
+    },
+    {
+      "cycle": 4,
+      "ts": "2026-07-04T08:11:26.000Z",
+      "newActionable": 4,
+      "quietCycles": 0,
+      "note": "New Codex review (commit 531d7d7) produced 4 new actionable threads. Handled 3522830247: reset ANTI_PATTERNS/GOOD_PATTERNS regex lastIndex before each test; committed/pushed b19f1e8 and replied in-thread. Remaining actionable: 3522830244 (preserve first added line), 3522830246 (match deps by basename), 3522830248 (forward start_side)."
+    }
+  ]
+}

--- a/.pr-maintainer-loop/heruujoko__github-review-mcp__3.json
+++ b/.pr-maintainer-loop/heruujoko__github-review-mcp__3.json
@@ -9,47 +9,55 @@
   "handledThreadIds": [
     "3522797510",
     "3522797511",
-    "3522830247"
+    "3522830247",
+    "3522830244"
   ],
   "inProgressThreadIds": [],
   "quietCycles": 0,
-  "cycleCount": 4,
-  "lastCycleAt": "2026-07-04T08:11:26.000Z",
+  "cycleCount": 5,
+  "lastCycleAt": "2026-07-04T08:14:42.000Z",
   "history": [
     {
       "cycle": 0,
       "ts": "2026-07-04T15:45:00.000Z",
       "newActionable": 0,
       "quietCycles": 0,
-      "note": "Loop seeded. Pre-existing inline review comments, top-level reviews, and issue comments inventory was empty."
+      "note": "Loop seeded."
     },
     {
       "cycle": 1,
       "ts": "2026-07-04T08:00:10.560397Z",
       "newActionable": 2,
       "quietCycles": 0,
-      "note": "Handled inline thread 3522797511: reset SECURITY_PATTERNS regex lastIndex before each test; committed/pushed 8e93521cacfab62d5446dc225c2c2748c6ce72f6 and replied in-thread. Remaining actionable: 3522797510 pagination."
+      "note": "Handled inline thread 3522797511: reset SECURITY_PATTERNS regex lastIndex before each test; committed/pushed 8e93521 and replied in-thread."
     },
     {
       "cycle": 2,
       "ts": "2026-07-04T08:04:45.942542Z",
       "newActionable": 1,
       "quietCycles": 0,
-      "note": "Handled inline thread 3522797510: paginated PR files, commits, and reviews via Octokit paginate; committed/pushed 531d7d70889c13faa1282583af8a80b4beca9fb2 and replied in-thread. Remaining actionable: none known; prior thread 3522797511 already handled."
+      "note": "Handled inline thread 3522797510: paginated PR files, commits, and reviews via Octokit paginate; committed/pushed 531d7d7 and replied in-thread."
     },
     {
       "cycle": 3,
       "ts": "2026-07-04T08:05:29.593272Z",
       "newActionable": 0,
       "quietCycles": 1,
-      "note": "Enumerated inline review comments, top-level reviews, and issue comments. No new actionable threads: Codex pagination thread 3522797510 and regex lastIndex thread 3522797511 were already handled with in-thread replies; top-level Codex review remains informational-only."
+      "note": "No new actionable threads."
     },
     {
       "cycle": 4,
       "ts": "2026-07-04T08:11:26.000Z",
       "newActionable": 4,
       "quietCycles": 0,
-      "note": "New Codex review (commit 531d7d7) produced 4 new actionable threads. Handled 3522830247: reset ANTI_PATTERNS/GOOD_PATTERNS regex lastIndex before each test; committed/pushed b19f1e8 and replied in-thread. Remaining actionable: 3522830244 (preserve first added line), 3522830246 (match deps by basename), 3522830248 (forward start_side)."
+      "note": "New Codex review produced 4 actionable threads. Handled 3522830247: reset ANTI_PATTERNS/GOOD_PATTERNS regex lastIndex; committed/pushed b19f1e8 and replied in-thread."
+    },
+    {
+      "cycle": 5,
+      "ts": "2026-07-04T08:14:42.000Z",
+      "newActionable": 3,
+      "quietCycles": 0,
+      "note": "Handled 3522830244: removed .slice(1) to preserve first added line in quality scoring; committed/pushed fee4722, replied in-thread, and resolved thread. Remaining actionable: 3522830246 (basename matching), 3522830248 (forward start_side)."
     }
   ]
 }

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-design.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-design.md
@@ -1,0 +1,227 @@
+# Design: github-review-mcp — Automated, Model-Agnostic Review Layer (`refactor/`)
+
+**Date:** 2026-07-03
+**Status:** Approved (design phase)
+**Location:** All new code under `refactor/`. The existing root package stays intact as the legacy/working version.
+
+---
+
+## 1. Purpose
+
+Evolve the current GitHub review MCP from an n8n-triggered, Gemini-driven, single-PAT service into a **model-agnostic, LLM-free MCP capability layer** that:
+
+- Serves any OpenAI-standard model via n8n's AI Agent node (deepseek, kimi, etc.) — no LLM logic inside MCP.
+- Uses a **GitHub App** (works on free GitHub accounts) instead of a long-lived PAT — short-lived, repo-scoped installation tokens; reviews post under a bot identity.
+- Resolves review strategy from a **file-driven catalog** (`refactor/strategies/*.md`) intersected with per-repo config (`.github/review-config.yaml`).
+- Supports **stateless follow-up reviews** — n8n tracks the last-reviewed SHA; MCP does pure diff math.
+- Is exposed as a **real MCP server over HTTP/SSE**, discoverable by n8n's MCP Client node.
+
+n8n remains the orchestrator and reasoning brain. MCP is a pure tool/capability backend.
+
+---
+
+## 2. Architecture
+
+### Roles
+
+| Concern | Owner |
+|---|---|
+| Trigger (PR open / follow-up push) | n8n (GitHub webhook → workflow) |
+| Model + reasoning loop | n8n AI Agent (any OpenAI-standard model) |
+| Strategy selection prompt | MCP (resolves repo config against catalog) |
+| GitHub access (read diff/files, post review) | MCP (via GitHub App installation token) |
+| Follow-up state (last-reviewed SHA) | n8n (stateless MCP) |
+| Notifications / control UI | n8n / Telegram |
+
+### Conversation flow
+
+```
+n8n Agent → MCP: get_review_strategy(owner, repo)
+MCP       → reads .github/review-config.yaml, intersects with strategies/*.md,
+            returns resolved strategy prompt(s)
+n8n Agent → MCP: get_pr_files / get_pr_details / get_pr_diff_range
+MCP       → mints installation token, fetches via Octokit, returns data
+n8n Agent → (reasons, loops, requests more tools) … until satisfied
+n8n Agent → MCP: post_pr_review(body, inline comments)
+MCP       → posts as GitHub App bot identity
+n8n       → Telegram notification
+```
+
+### Three-layer strategy model
+
+1. **MCP catalog** — `refactor/strategies/*.md`, each a strategy with skill-style frontmatter (metadata) + prompt body.
+2. **Repo config** — `.github/review-config.yaml` in each target repo, declaring allowed/preferred strategy names.
+3. **n8n** — never dictates strategy; it asks, MCP resolves from the repo config, returns the prompt(s).
+
+Resolution: `strategy.ts` loads all catalog files, parses frontmatter → metadata, keeps body as prompt. On `get_review_strategy`, MCP reads the repo config, intersects the repo's allowed strategy names with the available catalog, and returns matching prompt(s). If the repo has no config, fall back to a default strategy (e.g. `full-review`).
+
+---
+
+## 3. Language & Tooling
+
+- **All source in TypeScript.** `refactor/` is a self-contained TS package with its own `package.json` and `tsconfig.json`.
+- Modern `@modelcontextprotocol/sdk` (upgraded past `0.4.0`) for HTTP/SSE transport and shipped types.
+- Dev via `tsx` (watch), build via `tsc`.
+- Typed tool input schemas, shared domain types in `src/types/`.
+
+---
+
+## 4. Components & Structure
+
+```
+refactor/
+  package.json
+  tsconfig.json
+  .env.example
+  src/
+    server.ts           # MCP server over HTTP/SSE + header-secret auth
+    auth/
+      github-app.ts     # App JWT → installation token (cached, short-lived)
+    services/
+      github.ts         # Octokit wrapper bound to a per-installation token
+      strategy.ts       # loads strategies/*.md, parses frontmatter, resolves repo yaml
+      config.ts         # env config + repo allowlist
+    tools/
+      get_review_strategy.ts
+      get_pr_details.ts
+      get_pr_files.ts
+      get_pr_diff_range.ts
+      get_file_content.ts
+      post_pr_review.ts
+      analyze_*.ts       # pure-data analysis tools (ported from legacy, typed)
+      index.ts           # tool registry (definitions + handlers)
+    types/
+      index.ts           # Strategy, RepoConfig, PRRef, etc.
+  strategies/
+    security.md
+    performance.md
+    architecture.md
+    full-review.md
+    minimal.md
+```
+
+**Unit responsibilities (each has one clear job):**
+
+- `github-app.ts` — mint and cache short-lived installation tokens from App ID + private key. Input: owner/repo. Output: a scoped Octokit-ready token.
+- `strategy.ts` — parse the catalog, read a repo's `.github/review-config.yaml`, resolve to prompt(s). No GitHub write access.
+- `github.ts` — thin Octokit wrapper: PR details, files, file content, diff range, post review. Constructed per request with an installation token.
+- `config.ts` — env parsing (App ID, private key, header secret, repo allowlist, limits).
+- each `tools/*.ts` — a typed MCP tool: schema + handler that composes the services above.
+
+---
+
+## 5. Tool Catalog
+
+| Tool | Purpose | Notes |
+|---|---|---|
+| `get_review_strategy` | Resolve strategy prompt(s) for `{ owner, repo }` | Reads `.github/review-config.yaml`, intersects with catalog, returns prompt body(ies) |
+| `get_pr_details` | PR metadata | Ported from legacy |
+| `get_pr_files` | Files + patches for a PR | Ported |
+| `get_pr_diff_range` | **New** — diff between `base_sha` → `head_sha` | Enables stateless follow-up reviews |
+| `get_file_content` | File content at a ref | Ported |
+| `post_pr_review` | Post review body + inline comments | Posts as GitHub App bot identity |
+| `analyze_*` | Pure-data heuristics (security patterns, code patterns, deps, test coverage, etc.) | Ported, typed, return data only — no LLM reasoning |
+
+---
+
+## 6. Strategy File Format (skill-style frontmatter)
+
+```markdown
+---
+name: security
+description: Focused security vulnerability and input-validation review
+triggers:
+  - pr_with_secrets
+  - dependency_changes
+priority: 2
+---
+
+# Security Review Strategy
+
+You are reviewing this PR for security issues...
+[full prompt body returned to the n8n agent]
+```
+
+- **Frontmatter** = metadata (`name`, `description`, optional `triggers`, `priority`).
+- **Body** = the review prompt returned to n8n's agent.
+
+### Repo config (`.github/review-config.yaml`)
+
+```yaml
+strategies:
+  - security
+  - full-review
+default: full-review
+```
+
+MCP intersects `strategies` with the available catalog. `default` is used when n8n asks without a specific strategy or the repo lists none.
+
+---
+
+## 7. Security Model
+
+- **Transport auth:** header secret (Bearer/`x-api-key`) on the HTTP/SSE endpoint — carried over and hardened from the legacy `VALID_API_KEYS` model.
+- **GitHub auth:** GitHub App. Fly.io secrets store `GITHUB_APP_ID` and `GITHUB_APP_PRIVATE_KEY` (and optional `GITHUB_WEBHOOK_SECRET` if webhooks ever hit MCP directly). Installation tokens are minted per request, short-lived, repo-scoped.
+- **Repo allowlist:** MCP only operates on repos where the App is installed and (optionally) on an explicit allowlist in `config.ts`.
+- **No broad PAT** stored anywhere. No LLM keys in MCP (model lives in n8n).
+
+### Environment variables (`refactor/.env.example`)
+
+| Var | Description |
+|---|---|
+| `GITHUB_APP_ID` | GitHub App ID |
+| `GITHUB_APP_PRIVATE_KEY` | App private key (PEM) |
+| `MCP_API_SECRET` | Header secret for transport auth |
+| `REPO_ALLOWLIST` | Optional comma-separated `owner/repo` allowlist |
+| `PORT` | Server port (default 3000) |
+| `MAX_PATCH_SIZE` / `MAX_FILES_TO_REVIEW` / `REQUEST_TIMEOUT` | Limits (ported) |
+
+---
+
+## 8. Data Flow — Follow-up Review
+
+1. n8n receives a "PR synchronized" (new push) webhook.
+2. n8n recalls the last-reviewed SHA it stored for that PR.
+3. n8n calls `get_pr_diff_range({ pr_url, base_sha: last_reviewed, head_sha: latest })`.
+4. MCP returns only the changed diff for that range.
+5. n8n's agent reviews the incremental changes, calls `post_pr_review`.
+6. n8n stores the new head SHA as the latest reviewed.
+
+MCP holds no state across calls.
+
+---
+
+## 9. Error Handling
+
+- Invalid/missing header secret → 401.
+- Repo not in allowlist / App not installed → clear error to n8n (surfaceable to Telegram).
+- Repo config missing/malformed → fall back to `default` strategy, return a notice.
+- GitHub API failure → structured error returned to the tool caller (no silent empty responses, unlike the legacy fallback-strategy loop).
+- Strategy name requested that isn't in the catalog → error listing available strategies.
+
+---
+
+## 10. Testing
+
+- Unit: `strategy.ts` frontmatter parsing + repo-config resolution (including fallback + intersection edge cases).
+- Unit: `github-app.ts` token minting (mock JWT/installation), caching, expiry.
+- Unit: each tool handler with a mocked `github.ts`.
+- Integration: MCP server boots over HTTP/SSE, tool discovery returns the full catalog, a mocked end-to-end `get_review_strategy → get_pr_files → post_pr_review` sequence.
+
+---
+
+## 11. Out of Scope (YAGNI)
+
+- MCP-side persistence / DB (n8n owns follow-up state).
+- MCP-side LLM reasoning (n8n owns the model).
+- Separate strategy-config microservice (catalog lives in-repo as markdown).
+- Direct GitHub-webhook ingestion into MCP (n8n owns triggers).
+- Deprecating or modifying the legacy root package.
+
+---
+
+## 12. Migration / Coexistence
+
+- Legacy root package untouched; continues to run on Fly.io as-is until cutover.
+- `refactor/` deploys as a separate build target (own Dockerfile or build script) when ready.
+- Cutover is an n8n change: point the MCP Client node at the new HTTP/SSE endpoint.

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-plan.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: github-review-mcp `refactor/` (TypeScript, model-agnostic)
+
+**Date:** 2026-07-03
+**Design:** `docs/superpowers/specs/2026-07-03-mcp-review-refactor-design.md`
+**Scope:** All work under `refactor/`. Legacy root package untouched.
+
+Each step is ordered, independently testable, and lists its dependency + validation. Do not skip validation gates.
+
+---
+
+## Phase 0 — Package scaffold
+
+### Step 0.1 — Initialize TS package
+- **Do:** Create `refactor/package.json` (`"type": "module"`), `refactor/tsconfig.json` (NodeNext module resolution, `strict: true`, `outDir dist`), `.gitignore` additions for `refactor/dist`, `refactor/node_modules`.
+- **Deps:** `@modelcontextprotocol/sdk` (latest, HTTP/SSE-capable), `@octokit/rest`, `@octokit/auth-app`, `express`, `express-rate-limit`, `gray-matter` (frontmatter), `js-yaml`, `dotenv`. Dev: `typescript`, `tsx`, `@types/node`, `@types/express`, `@types/js-yaml`, `vitest` (or `node:test`).
+- **Scripts:** `dev` (tsx watch), `build` (tsc), `start` (node dist/server.js), `test`, `typecheck`.
+- **Validate:** `pnpm --dir refactor install` succeeds; `pnpm --dir refactor typecheck` passes on an empty `src/server.ts` stub.
+- **Depends on:** none.
+
+### Step 0.2 — Shared types
+- **Do:** `refactor/src/types/index.ts` — `PRRef` (`{ owner, repo, pull_number }`), `Strategy` (`{ name, description, triggers?, priority?, body }`), `RepoConfig` (`{ strategies: string[]; default?: string }`), tool result envelope types.
+- **Validate:** `typecheck` passes.
+- **Depends on:** 0.1.
+
+---
+
+## Phase 1 — Config & GitHub App auth (the foundation)
+
+### Step 1.1 — Config service
+- **Do:** `refactor/src/services/config.ts` — parse env: `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `MCP_API_SECRET`, `REPO_ALLOWLIST` (comma-split), `PORT`, `MAX_PATCH_SIZE`, `MAX_FILES_TO_REVIEW`, `REQUEST_TIMEOUT`. Provide `isRepoAllowed(owner, repo)`. Validate required vars, mask secrets in any debug output.
+- **Validate:** unit test — missing required var throws; allowlist matching works (empty allowlist = allow all installed repos); secrets masked.
+- **Depends on:** 0.2.
+
+### Step 1.2 — GitHub App token minting
+- **Do:** `refactor/src/auth/github-app.ts` — using `@octokit/auth-app`, mint short-lived installation tokens for `{ owner, repo }`. Cache tokens by installation with expiry (refresh before expiry). Expose `getInstallationOctokit(owner, repo)`.
+- **Validate:** unit test with mocked auth — returns an Octokit-ready token; cache returns same token within TTL; refreshes after expiry; unknown installation surfaces a clear error.
+- **Depends on:** 1.1.
+
+---
+
+## Phase 2 — Strategy engine
+
+### Step 2.1 — Strategy catalog loader
+- **Do:** `refactor/src/services/strategy.ts` — load `refactor/strategies/*.md`, parse with `gray-matter` into `Strategy` (frontmatter → metadata, body → prompt). Build a name→Strategy map. Cache on first load.
+- **Validate:** unit test with fixture `.md` files — parses frontmatter + body; duplicate names error; malformed frontmatter surfaces a clear error.
+- **Depends on:** 0.2.
+
+### Step 2.2 — Seed strategy files
+- **Do:** Create `refactor/strategies/{security,performance,architecture,full-review,minimal}.md` with skill-style frontmatter + prompt bodies (port review guidance from legacy `get_review_prompts.js`, split by concern).
+- **Validate:** loader (2.1) loads all five; each has non-empty `name`, `description`, `body`.
+- **Depends on:** 2.1.
+
+### Step 2.3 — Repo config resolution
+- **Do:** In `strategy.ts`, add `resolveForRepo(octokit, owner, repo)` — fetch `.github/review-config.yaml` via GitHub, parse with `js-yaml` into `RepoConfig`, intersect `strategies` with catalog, return resolved `Strategy[]`. Missing/malformed config → fall back to `default` (or `full-review`) with a notice. Requested-but-absent strategy → error listing available.
+- **Validate:** unit tests — intersection logic; missing-config fallback; malformed-yaml fallback + notice; unknown-strategy error.
+- **Depends on:** 2.1, 2.2, 1.2 (needs octokit to read the file).
+
+---
+
+## Phase 3 — GitHub service
+
+### Step 3.1 — Octokit wrapper
+- **Do:** `refactor/src/services/github.ts` — bound to an installation Octokit: `getPRDetails`, `getPRFiles`, `getFileContent`, `getDiffRange(base_sha, head_sha)` (via compare API), `createReview(body, event, comments[])`. Port + type from legacy `services/github.js`. Add `parsePRUrl`.
+- **Validate:** unit tests with mocked Octokit for each method incl. `getDiffRange` (compare commits) and inline-comment mapping in `createReview`.
+- **Depends on:** 1.2, 0.2.
+
+---
+
+## Phase 4 — Tools
+
+### Step 4.1 — Tool registry pattern
+- **Do:** `refactor/src/tools/index.ts` — typed registry: each tool exports `{ definition, handler }`; index aggregates `toolDefinitions` + `toolHandlers`. Handler signature receives resolved services (github, strategy, config) + typed args.
+- **Validate:** typecheck; registry lists all tools; unknown tool lookup returns undefined.
+- **Depends on:** 3.1, 2.3.
+
+### Step 4.2 — Individual tools
+- **Do:** Implement each in `refactor/src/tools/`:
+  - `get_review_strategy` → `strategy.resolveForRepo`
+  - `get_pr_details`, `get_pr_files`, `get_file_content`, `post_pr_review` → `github.ts`
+  - `get_pr_diff_range` → `github.getDiffRange`
+  - `analyze_*` → port pure-data analysis tools from legacy (typed, data-only)
+- **Validate:** unit test each handler with mocked services; `get_pr_diff_range` returns range diff; `post_pr_review` maps inline comments; allowlist enforced before any GitHub call.
+- **Depends on:** 4.1.
+
+---
+
+## Phase 5 — MCP server over HTTP/SSE
+
+### Step 5.1 — Server + transport
+- **Do:** `refactor/src/server.ts` — instantiate MCP `Server` with the modern SDK, register `ListTools` + `CallTool` from the registry, expose over HTTP/SSE (Streamable HTTP transport). Wrap in Express: header-secret auth middleware (`MCP_API_SECRET`), rate limiting, `/health`. Construct per-request installation Octokit via `github-app.ts` from tool args (owner/repo or parsed PR URL).
+- **Validate:** boot server; `/health` OK; MCP tool discovery over HTTP returns full catalog; unauthorized request → 401.
+- **Depends on:** 4.2, 1.1.
+
+### Step 5.2 — End-to-end integration test
+- **Do:** Integration test — boot server, connect an MCP client over HTTP, run `get_review_strategy → get_pr_files → post_pr_review` against mocked GitHub. Assert bot-identity posting path and stateless follow-up via `get_pr_diff_range`.
+- **Validate:** full sequence passes; no persisted state between calls.
+- **Depends on:** 5.1.
+
+---
+
+## Phase 6 — Packaging & docs
+
+### Step 6.1 — Deploy target
+- **Do:** `refactor/Dockerfile` (multi-stage TS build → `node dist/server.js`), `refactor/.env.example`, `refactor/.dockerignore`.
+- **Validate:** `docker build refactor/` succeeds; container serves `/health`.
+- **Depends on:** 5.1.
+
+### Step 6.2 — README + repo-config sample
+- **Do:** `refactor/README.md` — GitHub App setup steps (permissions: Pull requests R/W, Contents R, Metadata R; install on target repos), Fly.io secrets, n8n MCP Client wiring. Include a sample `.github/review-config.yaml`.
+- **Validate:** a reviewer can follow setup end-to-end without gaps.
+- **Depends on:** 6.1.
+
+---
+
+## Dependency graph (summary)
+
+```
+0.1 → 0.2 → {1.1 → 1.2 → 3.1, 2.1 → 2.2 → 2.3}
+2.3 needs 1.2 ; 3.1 + 2.3 → 4.1 → 4.2 → 5.1 → 5.2 → 6.1 → 6.2
+```
+
+## Global validation gates
+- `typecheck` + `test` green after every phase.
+- No secrets logged; no PAT anywhere; no LLM key in `refactor/`.
+- Legacy root package unmodified throughout.
+
+## Open items to confirm before coding
+- SDK package/version for HTTP/SSE transport (verify latest `@modelcontextprotocol/sdk` HTTP transport API at implementation time).
+- Test runner choice: `vitest` vs `node:test` (plan assumes either; pick at 0.1).
+- Which legacy `analyze_*` tools to port vs drop (default: port all as data-only).

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
@@ -31,9 +31,8 @@ Legend: ✅ done + green ✅   🟡 test red / stub ⏳   ⬜ not started
 
 ## Phase 4 — Tools
 - ✅ 4.1 Tool registry pattern (`tools/index.ts`) — committed `866ed60`; registerTool/getTool/toolDefinitions/resetRegistry + index.test.ts pass.
-- 🟡 4.2 Individual tools — **IN PROGRESS / BROKEN.** `shared.ts` (allowlist gate, service bundle, result formatting) exists. `tools/core.tools.test.ts` is UNTRACKED and FAILS TO LOAD: imports `./registry.js` which does not exist (registry lives in `index.ts`). No individual tool files exist yet (`get_review_strategy.ts`, `get_pr_details.ts`, `get_pr_files.ts`, `get_pr_diff_range.ts`, `get_file_content.ts`, `post_pr_review.ts`, `get_pr_commits.ts`, `get_repo_info.ts`, `analyze_*.ts`).
-  → Next action: (a) fix the broken `core.tools.test.ts` import path (likely needs `./index.js` or a real `registry.ts` split); (b) implement each individual tool consuming `shared.ts` helpers; (c) unit tests per tool with mocked services.
-- Gate: NOT met. ❌ Current `pnpm test` fails to load due to broken untracked test.
+- ✅ 4.2 Individual tools — implemented and green. `shared.ts` centralizes allowlist, GitHub service construction, and ToolResult envelopes. `tools/registry.ts` owns registry primitives; `tools/index.ts` aggregates and registers all tools. Implemented: `get_review_strategy`, `get_pr_details`, `get_pr_files`, `get_pr_commits`, `get_file_content`, `get_repo_info`, `get_pr_diff_range`, `post_pr_review`, `analyze_code_quality`, `analyze_diff_impact`, `analyze_dependencies`, `analyze_test_coverage`, `detect_security_issues`, `detect_code_patterns`. Data-only analysis heuristics live in `services/analysis.ts`.
+- Gate: green ✅ verified 2026-07-04 via `cd refactor && pnpm typecheck && pnpm test` → 57 tests passed.
 
 ## Phase 5 — MCP server over HTTP/SSE  ⬜
 - ⬜ 5.1 Server + transport (`server.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
@@ -1,0 +1,57 @@
+# Refactor Plan — Execution Checklist & Status
+
+**Plan:** `docs/superpowers/specs/2026-07-03-mcp-review-refactor-plan.md`
+**Design:** `docs/superpowers/specs/2026-07-03-mcp-review-refactor-design.md`
+**Worktree branch:** `pi-agent-29ed8bbc-5769-4cf` (awaiting merge to `refactor/mcp-review-typescript` or `main`)
+**Status source:** verified on disk 2026-07-03, NOT inferred from agent self-report.
+
+Legend: ✅ done + green ✅   🟡 test red / stub ⏳   ⬜ not started
+
+---
+
+## Phase 0 — Package scaffold
+- ✅ 0.1 Initialize TS package (`package.json`, `tsconfig.json`, deps, tsx, vitest, modern MCP SDK, `.gitignore`)
+- ✅ 0.2 Shared types (`refactor/src/types/index.ts`)
+- Gate: install ✓, typecheck ✓
+
+## Phase 1 — Config & GitHub App auth
+- ✅ 1.1 Config service (`services/config.ts`) — env parse, allowlist, secret masking — 10 tests pass
+- ✅ 1.2 GitHub App token minting (`auth/github-app.ts`) — install tokens, cache+TTL
+- Gate: tests green ✓
+
+## Phase 2 — Strategy engine
+- ✅ 2.1 Strategy catalog loader (`services/strategy.ts` load) — dup/malformed/empty guards
+- ✅ 2.2 Seed 5 strategy files (`strategies/{security,performance,architecture,full-review,minimal}.md`)
+- ✅ 2.3 Repo config resolution — intersect, fallback (default→full-review), unknown→error listing
+- Gate: 32 strategy+config tests green ✓
+
+## Phase 3 — GitHub service  ⚠️ BLOCKED (needs implementation)
+- 🟡 3.1 Octokit wrapper (`services/github.ts`) — **RED tests only, `github.ts` is a 1-line stub.** 13 tests failing: "GitHubService is not a constructor". Need to implement: `getPRDetails`, `getPRFiles`, `getFileContent`, `getDiffRange`, `createReview`, `getRepoInfo`, `parsePRUrl`.
+  → Next action: implement `github.ts` to green-up the existing tests (TDD green step).
+- Gate: NOT met. ❌
+
+## Phase 4 — Tools  ⬜
+- ⬜ 4.1 Tool registry pattern (`tools/index.ts`)
+- ⬜ 4.2 Individual tools (`get_review_strategy`, `get_pr_details`, `get_pr_files`, `get_pr_diff_range`, `get_file_content`, `post_pr_review`, `get_pr_commits`, `get_repo_info`, `analyze_*` ported data-only)
+- Gate: each tool unit-tested with mocked services. ⬜
+
+## Phase 5 — MCP server over HTTP/SSE  ⬜
+- ⬜ 5.1 Server + transport (`server.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit
+- ⬜ 5.2 End-to-end integration test (get_review_strategy → get_pr_files → post_pr_review, mocked GitHub)
+- Gate: server boots, discovery returns catalog, 401 on bad secret. ⬜
+
+## Phase 6 — Packaging & docs  ⬜
+- ⬜ 6.1 Deploy target (`refactor/Dockerfile`, `.env.example`, `.dockerignore`)
+- ⬜ 6.2 README + repo-config sample (GitHub App setup, Fly secrets, n8n MCP Client wiring, sample `.github/review-config.yaml`)
+
+---
+
+## Resolved decisions (coding-time)
+- Test runner: vitest ✓
+- Port scope: ALL `analyze_*` + `get_pr_commits` + `get_repo_info` as data-only tools
+- SDK: latest `@modelcontextprotocol/sdk`, verify Streamable HTTP transport at implementation
+
+## Notes
+- Phase 0–2 commits exist on the agent branch; Phase 3 tests committed but impl missing.
+- `github.test.ts` is the spec — implement `github.ts` to satisfy it (TDD green).
+- Do not trust agent summaries; re-verify each phase on disk before marking ✅.

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
@@ -25,15 +25,15 @@ Legend: ✅ done + green ✅   🟡 test red / stub ⏳   ⬜ not started
 - ✅ 2.3 Repo config resolution — intersect, fallback (default→full-review), unknown→error listing
 - Gate: 32 strategy+config tests green ✓
 
-## Phase 3 — GitHub service  ⚠️ BLOCKED (needs implementation)
-- 🟡 3.1 Octokit wrapper (`services/github.ts`) — **RED tests only, `github.ts` is a 1-line stub.** 13 tests failing: "GitHubService is not a constructor". Need to implement: `getPRDetails`, `getPRFiles`, `getFileContent`, `getDiffRange`, `createReview`, `getRepoInfo`, `parsePRUrl`.
-  → Next action: implement `github.ts` to green-up the existing tests (TDD green step).
-- Gate: NOT met. ❌
+## Phase 3 — GitHub service
+- ✅ 3.1 Octokit wrapper (`services/github.ts`) — committed `5f96cb7`; parseURL, getPRDetails/Files/Commits, getFileContent, getDiffRange (compare API), createReview (inline comment mapping), getRepoInfo. 13 tests pass.
+- Gate: green ✓ (verified 2026-07-03 via `pnpm vitest run --exclude '**/core.tools.test.ts'` → 50 passed)
 
-## Phase 4 — Tools  ⬜
-- ⬜ 4.1 Tool registry pattern (`tools/index.ts`)
-- ⬜ 4.2 Individual tools (`get_review_strategy`, `get_pr_details`, `get_pr_files`, `get_pr_diff_range`, `get_file_content`, `post_pr_review`, `get_pr_commits`, `get_repo_info`, `analyze_*` ported data-only)
-- Gate: each tool unit-tested with mocked services. ⬜
+## Phase 4 — Tools
+- ✅ 4.1 Tool registry pattern (`tools/index.ts`) — committed `866ed60`; registerTool/getTool/toolDefinitions/resetRegistry + index.test.ts pass.
+- 🟡 4.2 Individual tools — **IN PROGRESS / BROKEN.** `shared.ts` (allowlist gate, service bundle, result formatting) exists. `tools/core.tools.test.ts` is UNTRACKED and FAILS TO LOAD: imports `./registry.js` which does not exist (registry lives in `index.ts`). No individual tool files exist yet (`get_review_strategy.ts`, `get_pr_details.ts`, `get_pr_files.ts`, `get_pr_diff_range.ts`, `get_file_content.ts`, `post_pr_review.ts`, `get_pr_commits.ts`, `get_repo_info.ts`, `analyze_*.ts`).
+  → Next action: (a) fix the broken `core.tools.test.ts` import path (likely needs `./index.js` or a real `registry.ts` split); (b) implement each individual tool consuming `shared.ts` helpers; (c) unit tests per tool with mocked services.
+- Gate: NOT met. ❌ Current `pnpm test` fails to load due to broken untracked test.
 
 ## Phase 5 — MCP server over HTTP/SSE  ⬜
 - ⬜ 5.1 Server + transport (`server.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
@@ -39,9 +39,10 @@ Legend: ✅ done + green ✅   🟡 test red / stub ⏳   ⬜ not started
 - ✅ 5.2 End-to-end integration test — `integration.test.ts` boots the Express app with mocked services and verifies tool discovery, `get_review_strategy`, allowlist errors, unknown-tool errors, and auth rejection.
 - Gate: server boots, discovery returns catalog, sequential `tools/list` → `tools/call` returns 200 (regression for prior 500), 401 on bad secret. ✅ Verified 2026-07-04 via `cd refactor && npx tsc --noEmit && npx vitest run` → 62 tests passed.
 
-## Phase 6 — Packaging & docs  ⬜
-- ⬜ 6.1 Deploy target (`refactor/Dockerfile`, `.env.example`, `.dockerignore`)
-- ⬜ 6.2 README + repo-config sample (GitHub App setup, Fly secrets, n8n MCP Client wiring, sample `.github/review-config.yaml`)
+## Phase 6 — Packaging & docs
+- ✅ 6.1 Deploy target — added `refactor/Dockerfile`, `.env.example`, `.dockerignore`. Dockerfile performs multi-stage install/build and runs `node dist/src/server.js` with strategies available at runtime.
+- ✅ 6.2 README + repo-config sample — added `refactor/README.md` with GitHub App setup, env vars, Docker/Fly notes, n8n MCP Client wiring, and strategy config behavior. Added `refactor/examples/review-config.yaml`.
+- Gate: green ✅ verified 2026-07-04 via `cd refactor && pnpm typecheck && pnpm test && pnpm build`; `docker build -t github-review-mcp-refactor:test .`; container `/health` returned 200.
 
 ---
 

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
@@ -34,10 +34,10 @@ Legend: ✅ done + green ✅   🟡 test red / stub ⏳   ⬜ not started
 - ✅ 4.2 Individual tools — implemented and green. `shared.ts` centralizes allowlist, GitHub service construction, and ToolResult envelopes. `tools/registry.ts` owns registry primitives; `tools/index.ts` aggregates and registers all tools. Implemented: `get_review_strategy`, `get_pr_details`, `get_pr_files`, `get_pr_commits`, `get_file_content`, `get_repo_info`, `get_pr_diff_range`, `post_pr_review`, `analyze_code_quality`, `analyze_diff_impact`, `analyze_dependencies`, `analyze_test_coverage`, `detect_security_issues`, `detect_code_patterns`. Data-only analysis heuristics live in `services/analysis.ts`.
 - Gate: green ✅ verified 2026-07-04 via `cd refactor && pnpm typecheck && pnpm test` → 57 tests passed.
 
-## Phase 5 — MCP server over HTTP/SSE  ⬜
-- ⬜ 5.1 Server + transport (`server.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit
+## Phase 5 — MCP server over HTTP/SSE
+- ✅ 5.1 Server + transport (`server.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit. Verified: boots, `/health` 200, no-auth 401, ListTools returns 14 tools, unknown tool returns isError.
 - ⬜ 5.2 End-to-end integration test (get_review_strategy → get_pr_files → post_pr_review, mocked GitHub)
-- Gate: server boots, discovery returns catalog, 401 on bad secret. ⬜
+- Gate: server boots, discovery returns catalog, 401 on bad secret. ✅
 
 ## Phase 6 — Packaging & docs  ⬜
 - ⬜ 6.1 Deploy target (`refactor/Dockerfile`, `.env.example`, `.dockerignore`)

--- a/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
+++ b/docs/superpowers/specs/2026-07-03-mcp-review-refactor-progress.md
@@ -35,9 +35,9 @@ Legend: ✅ done + green ✅   🟡 test red / stub ⏳   ⬜ not started
 - Gate: green ✅ verified 2026-07-04 via `cd refactor && pnpm typecheck && pnpm test` → 57 tests passed.
 
 ## Phase 5 — MCP server over HTTP/SSE
-- ✅ 5.1 Server + transport (`server.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit. Verified: boots, `/health` 200, no-auth 401, ListTools returns 14 tools, unknown tool returns isError.
-- ⬜ 5.2 End-to-end integration test (get_review_strategy → get_pr_files → post_pr_review, mocked GitHub)
-- Gate: server boots, discovery returns catalog, 401 on bad secret. ✅
+- ✅ 5.1 Server + transport (`server.ts` + `app.ts`) — modern MCP SDK Streamable HTTP, header-secret auth, rate limit, `/health`, per-request install Octokit. Uses a per-request stateless Server + Transport so the SDK's stateless transport is never reused across POSTs. Verified: boots, `/health` 200, no-auth 401, ListTools returns 14 tools, unknown tool returns isError.
+- ✅ 5.2 End-to-end integration test — `integration.test.ts` boots the Express app with mocked services and verifies tool discovery, `get_review_strategy`, allowlist errors, unknown-tool errors, and auth rejection.
+- Gate: server boots, discovery returns catalog, sequential `tools/list` → `tools/call` returns 200 (regression for prior 500), 401 on bad secret. ✅ Verified 2026-07-04 via `cd refactor && npx tsc --noEmit && npx vitest run` → 62 tests passed.
 
 ## Phase 6 — Packaging & docs  ⬜
 - ⬜ 6.1 Deploy target (`refactor/Dockerfile`, `.env.example`, `.dockerignore`)

--- a/refactor/.dockerignore
+++ b/refactor/.dockerignore
@@ -1,0 +1,15 @@
+node_modules
+dist
+coverage
+.env
+.env.*
+!.env.example
+*.log
+.DS_Store
+.git
+.gitignore
+src/**/*.test.ts
+src/**/__fixtures__
+strategies/*.test.ts
+vitest.config.ts
+vitest.setup.ts

--- a/refactor/.env.example
+++ b/refactor/.env.example
@@ -1,0 +1,20 @@
+# GitHub App identity
+# Create a GitHub App, install it on target repositories, then copy its App ID
+# and private key here. In production, set these as platform secrets instead.
+GITHUB_APP_ID=123456
+GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+
+# Shared secret required by POST /mcp as the x-api-key header.
+MCP_API_SECRET=replace-with-a-long-random-secret
+
+# Optional HTTP port.
+PORT=3000
+
+# Optional comma-separated owner/repo allowlist. Empty = allow all repos where
+# the GitHub App is installed.
+# REPO_ALLOWLIST=octo-org/repo-a,octo-org/repo-b
+
+# Optional review payload limits.
+MAX_PATCH_SIZE=2000
+MAX_FILES_TO_REVIEW=50
+REQUEST_TIMEOUT=30000

--- a/refactor/.gitignore
+++ b/refactor/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+*.log
+.DS_Store
+coverage

--- a/refactor/Dockerfile
+++ b/refactor/Dockerfile
@@ -1,0 +1,36 @@
+# syntax=docker/dockerfile:1
+
+ARG NODE_VERSION=22.18.0
+
+FROM node:${NODE_VERSION}-slim AS base
+WORKDIR /app
+ENV NODE_ENV=production
+
+FROM base AS deps
+ENV PNPM_CONFIG_MINIMUM_RELEASE_AGE=0
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+FROM deps AS build
+ENV NODE_ENV=development
+COPY tsconfig.json ./
+COPY src ./src
+COPY strategies ./strategies
+RUN pnpm typecheck
+RUN pnpm build
+
+FROM base AS prod-deps
+ENV PNPM_CONFIG_MINIMUM_RELEASE_AGE=0
+RUN corepack enable
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --prod --frozen-lockfile
+
+FROM base AS runtime
+ENV PORT=3000
+COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/strategies ./strategies
+COPY package.json ./package.json
+EXPOSE 3000
+CMD ["node", "dist/src/server.js"]

--- a/refactor/README.md
+++ b/refactor/README.md
@@ -1,0 +1,208 @@
+# github-review-mcp refactor
+
+TypeScript, model-agnostic MCP capability server for GitHub pull-request review workflows.
+
+This package is intentionally isolated from the legacy root server. It does not run an LLM and does not own the review loop. n8n or another orchestrator asks this MCP server for GitHub data, review strategy prompts, and review-posting actions.
+
+## Architecture
+
+```text
+n8n / review agent
+  -> MCP Client over HTTP
+  -> POST /mcp with x-api-key
+  -> github-review-mcp
+       - GitHub App installation auth
+       - repo allowlist gate
+       - strategy catalog in strategies/*.md
+       - .github/review-config.yaml resolution
+       - PR data + diff + review posting tools
+```
+
+The server uses the MCP SDK Streamable HTTP transport in stateless mode. Each `/mcp` POST creates a fresh MCP `Server` and `StreamableHTTPServerTransport`, handles one request, then closes them. This avoids transport reuse bugs and keeps concurrent clients isolated.
+
+## Tools
+
+The server exposes 14 MCP tools:
+
+- `get_review_strategy`
+- `get_pr_details`
+- `get_pr_files`
+- `get_pr_commits`
+- `get_file_content`
+- `get_repo_info`
+- `get_pr_diff_range`
+- `post_pr_review`
+- `analyze_code_quality`
+- `analyze_diff_impact`
+- `analyze_dependencies`
+- `analyze_test_coverage`
+- `detect_security_issues`
+- `detect_code_patterns`
+
+## Local development
+
+```bash
+cd refactor
+pnpm install
+cp .env.example .env
+# edit .env
+pnpm typecheck
+pnpm test
+pnpm dev
+```
+
+Health check:
+
+```bash
+curl http://localhost:3000/health
+```
+
+MCP endpoint:
+
+```text
+POST http://localhost:3000/mcp
+Header: x-api-key: $MCP_API_SECRET
+Accept: application/json, text/event-stream
+Content-Type: application/json
+```
+
+## Required environment variables
+
+| Variable | Required | Description |
+|---|---:|---|
+| `GITHUB_APP_ID` | yes | Numeric GitHub App ID. |
+| `GITHUB_APP_PRIVATE_KEY` | yes | GitHub App private key PEM. Use escaped newlines in env files/secrets if needed. |
+| `MCP_API_SECRET` | yes | Shared secret required as `x-api-key` on `/mcp`. |
+| `PORT` | no | HTTP port. Default: `3000`. |
+| `REPO_ALLOWLIST` | no | Comma-separated `owner/repo` list. Empty means any repo where the App is installed. |
+| `MAX_PATCH_SIZE` | no | Patch truncation/analysis limit. Default: `2000`. |
+| `MAX_FILES_TO_REVIEW` | no | File-count limit. Default: `50`. |
+| `REQUEST_TIMEOUT` | no | Request timeout knob for service code. Default: `30000`. |
+
+## GitHub App setup
+
+You can use a free GitHub account. No GitHub upgrade is required.
+
+1. Create a GitHub App under your account or organization.
+2. Set the App permissions:
+   - **Metadata:** Read-only
+   - **Contents:** Read-only
+   - **Pull requests:** Read and write
+3. Optional but useful webhook events if n8n receives GitHub events directly:
+   - Pull request
+   - Pull request review
+   - Pull request review comment
+4. Generate a private key and store it as `GITHUB_APP_PRIVATE_KEY`.
+5. Install the App on the repositories you want reviewed.
+6. Set `REPO_ALLOWLIST` if you want an additional server-side repo gate beyond App installation scope.
+
+## Repository review config
+
+Each target repository can declare its allowed/preferred strategies at:
+
+```text
+.github/review-config.yaml
+```
+
+Example:
+
+```yaml
+strategies:
+  - full-review
+  - security
+  - architecture
+
+default: full-review
+```
+
+A copy is available at `examples/review-config.yaml`.
+
+Resolution behavior:
+
+- Missing config falls back to `full-review` with a notice.
+- Malformed config falls back to `full-review` with a notice.
+- Unknown strategy names fail with a clear error listing available strategies.
+- If a caller requests a strategy not allowed by the repo config, the tool returns an error listing allowed strategies.
+
+## n8n wiring
+
+Recommended flow:
+
+1. GitHub or Telegram trigger starts the n8n workflow.
+2. n8n calls MCP tool `get_review_strategy` with `{ owner, repo }`.
+3. n8n uses the returned strategy prompt with its chosen OpenAI-compatible model.
+4. n8n pulls required context using tools such as:
+   - `get_pr_details`
+   - `get_pr_files`
+   - `get_pr_diff_range`
+   - `get_file_content`
+5. n8n runs its review loop.
+6. n8n posts the final review through `post_pr_review`.
+
+MCP Client settings:
+
+- URL: `https://<your-host>/mcp`
+- Method/transport: Streamable HTTP / HTTP MCP client
+- Header: `x-api-key: <MCP_API_SECRET>`
+- Ensure the client sends:
+  - `Accept: application/json, text/event-stream`
+  - `Content-Type: application/json`
+
+## Docker
+
+Build from the `refactor/` directory:
+
+```bash
+docker build -t github-review-mcp-refactor .
+```
+
+Run locally:
+
+```bash
+docker run --rm -p 3000:3000 \
+  --env-file .env \
+  github-review-mcp-refactor
+```
+
+Then verify:
+
+```bash
+curl http://localhost:3000/health
+```
+
+## Fly.io notes
+
+One possible deployment flow:
+
+```bash
+cd refactor
+fly launch --no-deploy
+fly secrets set \
+  GITHUB_APP_ID="123456" \
+  GITHUB_APP_PRIVATE_KEY="$(cat path/to/private-key.pem)" \
+  MCP_API_SECRET="$(openssl rand -hex 32)"
+fly deploy
+```
+
+If you use `REPO_ALLOWLIST`, set it as a secret too:
+
+```bash
+fly secrets set REPO_ALLOWLIST="owner/repo-a,owner/repo-b"
+```
+
+## Validation
+
+Current green checks:
+
+```bash
+pnpm typecheck
+pnpm test
+```
+
+The integration test boots the Express app with mocked services and verifies:
+
+- tool discovery returns all 14 tools
+- `get_review_strategy` returns a strategy prompt
+- allowlist failures are returned as MCP `isError`
+- unknown tools are returned as MCP `isError`
+- bad `x-api-key` returns HTTP 401

--- a/refactor/examples/review-config.yaml
+++ b/refactor/examples/review-config.yaml
@@ -1,0 +1,14 @@
+# Place this file in a target repository at:
+#   .github/review-config.yaml
+#
+# Strategy names must match files in this MCP server's strategies/ directory.
+# The MCP tool get_review_strategy resolves this file against the local catalog
+# and returns the matching prompt body to n8n.
+
+strategies:
+  - full-review
+  - security
+  - architecture
+
+# Optional fallback used when no specific strategy is requested.
+default: full-review

--- a/refactor/package.json
+++ b/refactor/package.json
@@ -2,16 +2,17 @@
   "name": "mcp-review-server",
   "version": "0.1.0",
   "private": true,
+  "packageManager": "pnpm@10.15.0",
   "description": "Model-agnostic, LLM-free MCP capability layer for GitHub PR review (GitHub App powered).",
   "type": "module",
-  "main": "dist/server.js",
+  "main": "dist/src/server.js",
   "engines": {
     "node": ">=20"
   },
   "scripts": {
     "dev": "tsx watch src/server.ts",
     "build": "tsc",
-    "start": "node dist/server.js",
+    "start": "node dist/src/server.js",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit"
@@ -34,5 +35,10 @@
     "typescript": "^5.6.0",
     "vitest": "^2.1.0"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "esbuild"
+    ]
+  }
 }

--- a/refactor/package.json
+++ b/refactor/package.json
@@ -1,0 +1,38 @@
+{
+  "name": "mcp-review-server",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Model-agnostic, LLM-free MCP capability layer for GitHub PR review (GitHub App powered).",
+  "type": "module",
+  "main": "dist/server.js",
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "dev": "tsx watch src/server.ts",
+    "build": "tsc",
+    "start": "node dist/server.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "latest",
+    "@octokit/auth-app": "^8.0.0",
+    "@octokit/rest": "^21.0.0",
+    "dotenv": "^16.4.5",
+    "express": "^5.1.0",
+    "express-rate-limit": "^8.0.1",
+    "gray-matter": "^4.0.3",
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/express": "^5.0.0",
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^22.0.0",
+    "tsx": "^4.19.0",
+    "typescript": "^5.6.0",
+    "vitest": "^2.1.0"
+  },
+  "license": "MIT"
+}

--- a/refactor/pnpm-lock.yaml
+++ b/refactor/pnpm-lock.yaml
@@ -1,0 +1,2389 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@modelcontextprotocol/sdk':
+        specifier: latest
+        version: 1.29.0(zod@4.4.3)
+      '@octokit/auth-app':
+        specifier: ^8.0.0
+        version: 8.2.0
+      '@octokit/rest':
+        specifier: ^21.0.0
+        version: 21.1.1
+      dotenv:
+        specifier: ^16.4.5
+        version: 16.6.1
+      express:
+        specifier: ^5.1.0
+        version: 5.2.1
+      express-rate-limit:
+        specifier: ^8.0.1
+        version: 8.5.2(express@5.2.1)
+      gray-matter:
+        specifier: ^4.0.3
+        version: 4.0.3
+      js-yaml:
+        specifier: ^4.1.0
+        version: 4.3.0
+    devDependencies:
+      '@types/express':
+        specifier: ^5.0.0
+        version: 5.0.6
+      '@types/js-yaml':
+        specifier: ^4.0.9
+        version: 4.0.9
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.0
+      tsx:
+        specifier: ^4.19.0
+        version: 4.23.0
+      typescript:
+        specifier: ^5.6.0
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.0
+        version: 2.1.9(@types/node@22.20.0)
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
+
+  '@octokit/auth-app@8.2.0':
+    resolution: {integrity: sha512-vVjdtQQwomrZ4V46B9LaCsxsySxGoHsyw6IYBov/TqJVROrlYdyNgw5q6tQbB7KZt53v1l1W53RiqTvpzL907g==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-app@9.0.3':
+    resolution: {integrity: sha512-+yoFQquaF8OxJSxTb7rnytBIC2ZLbLqA/yb71I4ZXT9+Slw4TziV9j/kyGhUFRRTF2+7WlnIWsePZCWHs+OGjg==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-device@8.0.3':
+    resolution: {integrity: sha512-zh2W0mKKMh/VWZhSqlaCzY7qFyrgd9oTWmTmHaXnHNeQRCZr/CXy2jCgHo4e4dJVTiuxP5dLa0YM5p5QVhJHbw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-oauth-user@6.0.2':
+    resolution: {integrity: sha512-qLoPPc6E6GJoz3XeDG/pnDhJpTkODTGG4kY0/Py154i/I003O9NazkrwJwRuzgCalhzyIeWQ+6MDvkUmKXjg/A==}
+    engines: {node: '>= 20'}
+
+  '@octokit/auth-token@5.1.2':
+    resolution: {integrity: sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==}
+    engines: {node: '>= 18'}
+
+  '@octokit/core@6.1.6':
+    resolution: {integrity: sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@10.1.4':
+    resolution: {integrity: sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/endpoint@11.0.3':
+    resolution: {integrity: sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==}
+    engines: {node: '>= 20'}
+
+  '@octokit/graphql@8.2.2':
+    resolution: {integrity: sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/oauth-authorization-url@8.0.0':
+    resolution: {integrity: sha512-7QoLPRh/ssEA/HuHBHdVdSgF8xNLz/Bc5m9fZkArJE5bb6NmVkDm3anKxXPmN1zh6b5WKZPRr3697xKT/yM3qQ==}
+    engines: {node: '>= 20'}
+
+  '@octokit/oauth-methods@6.0.2':
+    resolution: {integrity: sha512-HiNOO3MqLxlt5Da5bZbLV8Zarnphi4y9XehrbaFMkcoJ+FL7sMxH/UlUsCVxpddVu4qvNDrBdaTVE2o4ITK8ng==}
+    engines: {node: '>= 20'}
+
+  '@octokit/openapi-types@24.2.0':
+    resolution: {integrity: sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==}
+
+  '@octokit/openapi-types@25.1.0':
+    resolution: {integrity: sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA==}
+
+  '@octokit/openapi-types@27.0.0':
+    resolution: {integrity: sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==}
+
+  '@octokit/plugin-paginate-rest@11.6.0':
+    resolution: {integrity: sha512-n5KPteiF7pWKgBIBJSk8qzoZWcUkza2O6A0za97pMGVrGfPdltxrfmfF5GucHYvHGZD8BdaZmmHGz5cX/3gdpw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-request-log@5.3.1':
+    resolution: {integrity: sha512-n/lNeCtq+9ofhC15xzmJCNKP2BWTv8Ih2TTy+jatNCCq/gQP/V7rK3fjIfuz0pDWDALO/o/4QY4hyOF6TQQFUw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/plugin-rest-endpoint-methods@13.5.0':
+    resolution: {integrity: sha512-9Pas60Iv9ejO3WlAX3maE1+38c5nqbJXV5GrncEfkndIpZrJ/WPMRd2xYDcPPEt5yzpxcjw9fWNoPhsSGzqKqw==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      '@octokit/core': '>=6'
+
+  '@octokit/request-error@6.1.8':
+    resolution: {integrity: sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ==}
+    engines: {node: '>= 18'}
+
+  '@octokit/request-error@7.1.0':
+    resolution: {integrity: sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@10.0.11':
+    resolution: {integrity: sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==}
+    engines: {node: '>= 20'}
+
+  '@octokit/request@9.2.4':
+    resolution: {integrity: sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA==}
+    engines: {node: '>= 18'}
+
+  '@octokit/rest@21.1.1':
+    resolution: {integrity: sha512-sTQV7va0IUVZcntzy1q3QqPm/r8rWtDCqpRAmb8eXXnKkjoQEtFe3Nt5GTVsHft+R6jJoHeSiVLcgcvhtue/rg==}
+    engines: {node: '>= 18'}
+
+  '@octokit/types@13.10.0':
+    resolution: {integrity: sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==}
+
+  '@octokit/types@14.1.0':
+    resolution: {integrity: sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g==}
+
+  '@octokit/types@16.0.0':
+    resolution: {integrity: sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==}
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/body-parser@1.19.6':
+    resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
+
+  '@types/connect@3.4.38':
+    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/express-serve-static-core@5.1.1':
+    resolution: {integrity: sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==}
+
+  '@types/express@5.0.6':
+    resolution: {integrity: sha512-sKYVuV7Sv9fbPIt/442koC7+IIwK5olP1KWeD88e/idgoJqDm3JV/YUiPwkoKK92ylff2MGxSz1CSjsXelx0YA==}
+
+  '@types/http-errors@2.0.5':
+    resolution: {integrity: sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==}
+
+  '@types/js-yaml@4.0.9':
+    resolution: {integrity: sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg==}
+
+  '@types/node@22.20.0':
+    resolution: {integrity: sha512-QWlFW2wf3nTjC13/DqRnBpR4ZO36VJH/JVBkA/vcnmbTBNQIlnObqyqZE1tUR7+Ni23Lda8R1BxMfbXRpCUx5g==}
+
+  '@types/qs@6.15.1':
+    resolution: {integrity: sha512-GZHUBZR9hckSUhrxmp1nG6NwdpM9fCunJwyThLW1X3AyHgd9IlHb6VANpQQqDr2o/qQp6McZ3y/IA2rVzKzSbw==}
+
+  '@types/range-parser@1.2.7':
+    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
+
+  '@types/send@1.2.1':
+    resolution: {integrity: sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==}
+
+  '@types/serve-static@2.2.0':
+    resolution: {integrity: sha512-8mam4H1NHLtu7nmtalF7eyBH14QyOASmcxHhSfEoRyr0nP/YdoesEtU+uSRvMe96TW/HPTtkoKqQLl53N7UXMQ==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  argparse@1.0.10:
+    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
+
+  argparse@2.0.1:
+    resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  before-after-hook@3.0.2:
+    resolution: {integrity: sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==}
+
+  body-parser@2.3.0:
+    resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
+    engines: {node: '>=18'}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
+  cross-spawn@7.0.6:
+    resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
+    engines: {node: '>= 8'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  es-object-atoms@1.1.2:
+    resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
+    engines: {node: '>= 0.4'}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  eventsource-parser@3.1.0:
+    resolution: {integrity: sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
+
+  extend-shallow@2.0.1:
+    resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
+    engines: {node: '>=0.10.0'}
+
+  fast-content-type-parse@2.0.1:
+    resolution: {integrity: sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-uri@3.1.3:
+    resolution: {integrity: sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
+
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
+
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
+  gray-matter@4.0.3:
+    resolution: {integrity: sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==}
+    engines: {node: '>=6.0'}
+
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  hono@4.12.27:
+    resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
+    engines: {node: '>=16.9.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
+    engines: {node: '>=0.10.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
+
+  is-extendable@0.1.1:
+    resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
+    engines: {node: '>=0.10.0'}
+
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
+  isexe@2.0.0:
+    resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
+  js-yaml@3.15.0:
+    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+    hasBin: true
+
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+    hasBin: true
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
+  json-with-bigint@3.5.8:
+    resolution: {integrity: sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==}
+
+  kind-of@6.0.3:
+    resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
+    engines: {node: '>=0.10.0'}
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.15:
+    resolution: {integrity: sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  negotiator@1.0.0:
+    resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
+    engines: {node: '>= 0.6'}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
+  path-key@3.1.1:
+    resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
+    engines: {node: '>=8'}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
+
+  postcss@8.5.16:
+    resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
+  range-parser@1.3.0:
+    resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
+    engines: {node: '>= 0.6'}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  section-matter@1.0.0:
+    resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
+    engines: {node: '>=4'}
+
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  shebang-command@2.0.0:
+    resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
+    engines: {node: '>=8'}
+
+  shebang-regex@3.0.0:
+    resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
+    engines: {node: '>=8'}
+
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
+    engines: {node: '>= 0.4'}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  sprintf-js@1.0.3:
+    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  strip-bom-string@1.0.0:
+    resolution: {integrity: sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==}
+    engines: {node: '>=0.10.0'}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  toad-cache@3.7.4:
+    resolution: {integrity: sha512-m1TdR/rvT7kgGJZhspNtXdsdYk0fddFpJJFlG5s+UkPFo6lkLoZ3YLOaovPYjq1R75NP5JfeTlSHaOsE09peCg==}
+    engines: {node: '>=20'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  universal-github-app-jwt@2.2.2:
+    resolution: {integrity: sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw==}
+
+  universal-user-agent@7.0.3:
+    resolution: {integrity: sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which@2.0.2:
+    resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
+    engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
+    optional: true
+
+  '@hono/node-server@1.19.14(hono@4.12.27)':
+    dependencies:
+      hono: 4.12.27
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.27)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.1.0
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.27
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@octokit/auth-app@8.2.0':
+    dependencies:
+      '@octokit/auth-oauth-app': 9.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      toad-cache: 3.7.4
+      universal-github-app-jwt: 2.2.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-app@9.0.3':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/auth-oauth-user': 6.0.2
+      '@octokit/request': 10.0.11
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-device@8.0.3':
+    dependencies:
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.11
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-oauth-user@6.0.2':
+    dependencies:
+      '@octokit/auth-oauth-device': 8.0.3
+      '@octokit/oauth-methods': 6.0.2
+      '@octokit/request': 10.0.11
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/auth-token@5.1.2': {}
+
+  '@octokit/core@6.1.6':
+    dependencies:
+      '@octokit/auth-token': 5.1.2
+      '@octokit/graphql': 8.2.2
+      '@octokit/request': 9.2.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      before-after-hook: 3.0.2
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@10.1.4':
+    dependencies:
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/endpoint@11.0.3':
+    dependencies:
+      '@octokit/types': 16.0.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/graphql@8.2.2':
+    dependencies:
+      '@octokit/request': 9.2.4
+      '@octokit/types': 14.1.0
+      universal-user-agent: 7.0.3
+
+  '@octokit/oauth-authorization-url@8.0.0': {}
+
+  '@octokit/oauth-methods@6.0.2':
+    dependencies:
+      '@octokit/oauth-authorization-url': 8.0.0
+      '@octokit/request': 10.0.11
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+
+  '@octokit/openapi-types@24.2.0': {}
+
+  '@octokit/openapi-types@25.1.0': {}
+
+  '@octokit/openapi-types@27.0.0': {}
+
+  '@octokit/plugin-paginate-rest@11.6.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 13.10.0
+
+  '@octokit/plugin-request-log@5.3.1(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+
+  '@octokit/plugin-rest-endpoint-methods@13.5.0(@octokit/core@6.1.6)':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/types': 13.10.0
+
+  '@octokit/request-error@6.1.8':
+    dependencies:
+      '@octokit/types': 14.1.0
+
+  '@octokit/request-error@7.1.0':
+    dependencies:
+      '@octokit/types': 16.0.0
+
+  '@octokit/request@10.0.11':
+    dependencies:
+      '@octokit/endpoint': 11.0.3
+      '@octokit/request-error': 7.1.0
+      '@octokit/types': 16.0.0
+      content-type: 2.0.0
+      json-with-bigint: 3.5.8
+      universal-user-agent: 7.0.3
+
+  '@octokit/request@9.2.4':
+    dependencies:
+      '@octokit/endpoint': 10.1.4
+      '@octokit/request-error': 6.1.8
+      '@octokit/types': 14.1.0
+      fast-content-type-parse: 2.0.1
+      universal-user-agent: 7.0.3
+
+  '@octokit/rest@21.1.1':
+    dependencies:
+      '@octokit/core': 6.1.6
+      '@octokit/plugin-paginate-rest': 11.6.0(@octokit/core@6.1.6)
+      '@octokit/plugin-request-log': 5.3.1(@octokit/core@6.1.6)
+      '@octokit/plugin-rest-endpoint-methods': 13.5.0(@octokit/core@6.1.6)
+
+  '@octokit/types@13.10.0':
+    dependencies:
+      '@octokit/openapi-types': 24.2.0
+
+  '@octokit/types@14.1.0':
+    dependencies:
+      '@octokit/openapi-types': 25.1.0
+
+  '@octokit/types@16.0.0':
+    dependencies:
+      '@octokit/openapi-types': 27.0.0
+
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    optional: true
+
+  '@types/body-parser@1.19.6':
+    dependencies:
+      '@types/connect': 3.4.38
+      '@types/node': 22.20.0
+
+  '@types/connect@3.4.38':
+    dependencies:
+      '@types/node': 22.20.0
+
+  '@types/estree@1.0.9': {}
+
+  '@types/express-serve-static-core@5.1.1':
+    dependencies:
+      '@types/node': 22.20.0
+      '@types/qs': 6.15.1
+      '@types/range-parser': 1.2.7
+      '@types/send': 1.2.1
+
+  '@types/express@5.0.6':
+    dependencies:
+      '@types/body-parser': 1.19.6
+      '@types/express-serve-static-core': 5.1.1
+      '@types/serve-static': 2.2.0
+
+  '@types/http-errors@2.0.5': {}
+
+  '@types/js-yaml@4.0.9': {}
+
+  '@types/node@22.20.0':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/qs@6.15.1': {}
+
+  '@types/range-parser@1.2.7': {}
+
+  '@types/send@1.2.1':
+    dependencies:
+      '@types/node': 22.20.0
+
+  '@types/serve-static@2.2.0':
+    dependencies:
+      '@types/http-errors': 2.0.5
+      '@types/node': 22.20.0
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.20.0))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.20.0)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  argparse@1.0.10:
+    dependencies:
+      sprintf-js: 1.0.3
+
+  argparse@2.0.1: {}
+
+  assertion-error@2.0.1: {}
+
+  before-after-hook@3.0.2: {}
+
+  body-parser@2.3.0:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 2.0.0
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  bytes@3.1.2: {}
+
+  cac@6.7.14: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
+  cross-spawn@7.0.6:
+    dependencies:
+      path-key: 3.1.1
+      shebang-command: 2.0.0
+      which: 2.0.2
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  depd@2.0.0: {}
+
+  dotenv@16.6.1: {}
+
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
+  ee-first@1.1.1: {}
+
+  encodeurl@2.0.0: {}
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  es-object-atoms@1.1.2:
+    dependencies:
+      es-errors: 1.3.0
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
+
+  escape-html@1.0.3: {}
+
+  esprima@4.0.1: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  etag@1.8.1: {}
+
+  eventsource-parser@3.1.0: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.1.0
+
+  expect-type@1.4.0: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.3.0
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.3.0
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
+  extend-shallow@2.0.1:
+    dependencies:
+      is-extendable: 0.1.1
+
+  fast-content-type-parse@2.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-uri@3.1.3: {}
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  forwarded@0.2.0: {}
+
+  fresh@2.0.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.2
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.4
+      math-intrinsics: 1.1.0
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.2
+
+  gopd@1.2.0: {}
+
+  gray-matter@4.0.3:
+    dependencies:
+      js-yaml: 3.15.0
+      kind-of: 6.0.3
+      section-matter: 1.0.0
+      strip-bom-string: 1.0.0
+
+  has-symbols@1.1.0: {}
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  hono@4.12.27: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  inherits@2.0.4: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
+
+  is-extendable@0.1.1: {}
+
+  is-promise@4.0.0: {}
+
+  isexe@2.0.0: {}
+
+  jose@6.2.3: {}
+
+  js-yaml@3.15.0:
+    dependencies:
+      argparse: 1.0.10
+      esprima: 4.0.1
+
+  js-yaml@4.3.0:
+    dependencies:
+      argparse: 2.0.1
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
+  json-with-bigint@3.5.8: {}
+
+  kind-of@6.0.3: {}
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  math-intrinsics@1.1.0: {}
+
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.15: {}
+
+  negotiator@1.0.0: {}
+
+  object-assign@4.1.1: {}
+
+  object-inspect@1.13.4: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  parseurl@1.3.3: {}
+
+  path-key@3.1.1: {}
+
+  path-to-regexp@8.4.2: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  pkce-challenge@5.0.1: {}
+
+  postcss@8.5.16:
+    dependencies:
+      nanoid: 3.3.15
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
+  range-parser@1.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
+
+  require-from-string@2.0.2: {}
+
+  rollup@4.62.2:
+    dependencies:
+      '@types/estree': 1.0.9
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
+      fsevents: 2.3.3
+
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
+  safer-buffer@2.1.2: {}
+
+  section-matter@1.0.0:
+    dependencies:
+      extend-shallow: 2.0.1
+      kind-of: 6.0.3
+
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.3.0
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
+  setprototypeof@1.2.0: {}
+
+  shebang-command@2.0.0:
+    dependencies:
+      shebang-regex: 3.0.0
+
+  shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  sprintf-js@1.0.3: {}
+
+  stackback@0.0.2: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  strip-bom-string@1.0.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  toad-cache@3.7.4: {}
+
+  toidentifier@1.0.1: {}
+
+  tsx@4.23.0:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
+
+  typescript@5.9.3: {}
+
+  undici-types@6.21.0: {}
+
+  universal-github-app-jwt@2.2.2: {}
+
+  universal-user-agent@7.0.3: {}
+
+  unpipe@1.0.0: {}
+
+  vary@1.1.2: {}
+
+  vite-node@2.1.9(@types/node@22.20.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.20.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.20.0):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.16
+      rollup: 4.62.2
+    optionalDependencies:
+      '@types/node': 22.20.0
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.20.0):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.20.0))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.20.0)
+      vite-node: 2.1.9(@types/node@22.20.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.20.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which@2.0.2:
+    dependencies:
+      isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrappy@1.0.2: {}
+
+  zod-to-json-schema@3.25.2(zod@4.4.3):
+    dependencies:
+      zod: 4.4.3
+
+  zod@4.4.3: {}

--- a/refactor/src/app.ts
+++ b/refactor/src/app.ts
@@ -1,0 +1,142 @@
+/**
+ * MCP server factory — creates an Express app wired to the MCP SDK's
+ * Streamable HTTP transport with header-secret auth, rate limiting, and
+ * the tool registry.
+ *
+ * The factory accepts an optional `overrides` object so integration tests
+ * can inject mock services without touching env vars.
+ */
+
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { ConfigService } from './services/config.js';
+import { GitHubAppAuth, createAppOctokit } from './auth/github-app.js';
+import { StrategyService } from './services/strategy.js';
+import { registerAllTools, getTool, toolDefinitions } from './tools/index.js';
+import type { ToolServices } from './types/index.js';
+
+export interface ServerOverrides {
+  config?: ConfigService;
+  githubApp?: GitHubAppAuth;
+  strategy?: StrategyService;
+  mcpApiSecret?: string;
+}
+
+/**
+ * Build a fully wired Express app. When `overrides` are provided they
+ * replace the corresponding production service; the caller is responsible
+ * for ensuring the override implements the required interface.
+ */
+export function createApp(overrides: ServerOverrides = {}): {
+  app: express.Application;
+  services: ToolServices;
+} {
+  const config = overrides.config ?? new ConfigService();
+  const mcpApiSecret = overrides.mcpApiSecret ?? config.mcpApiSecret;
+
+  const appOctokit = createAppOctokit(config.githubAppId, config.githubAppPrivateKey);
+  const githubApp =
+    overrides.githubApp ??
+    new GitHubAppAuth({
+      appId: config.githubAppId,
+      privateKey: config.githubAppPrivateKey,
+      appOctokit: appOctokit as never,
+    });
+  const strategy = overrides.strategy ?? new StrategyService();
+
+  const services: ToolServices = { config, githubApp, strategy };
+
+  registerAllTools();
+
+  // Build a fresh MCP Server wired to the tool registry. A new instance is
+  // created per request (stateless transport model) so state never leaks
+  // between concurrent clients.
+  function buildMcpServer(): Server {
+    const mcpServer = new Server(
+      { name: 'github-review-mcp', version: '0.1.0' },
+      { capabilities: { tools: {} } },
+    );
+
+    mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+      tools: toolDefinitions,
+    }));
+
+    mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      const entry = getTool(name);
+      if (!entry) {
+        return {
+          content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
+          isError: true,
+        };
+      }
+      return entry.handler(args ?? {}, services) as never;
+    });
+
+    return mcpServer;
+  }
+
+  const app = express();
+  app.set('trust proxy', 1);
+
+  const limiter = rateLimit({
+    windowMs: 60_000,
+    max: 100,
+    standardHeaders: true,
+    legacyHeaders: false,
+    message: { error: 'Too many requests, please try again later.' },
+  });
+  app.use(limiter);
+
+  function authMiddleware(
+    req: express.Request,
+    res: express.Response,
+    next: express.NextFunction,
+  ): void {
+    const provided = req.headers['x-api-key'] as string | undefined;
+    if (!provided || provided !== mcpApiSecret) {
+      res.status(401).json({ error: 'Unauthorized: invalid or missing x-api-key header' });
+      return;
+    }
+    next();
+  }
+
+  app.get('/health', (_req, res) => {
+    res.json({ status: 'ok', version: '0.1.0' });
+  });
+
+  // Stateless Streamable HTTP model: a fresh Server + Transport is created for
+  // every POST, connected, used to handle the single request, then torn down
+  // when the response closes. This avoids the "transport cannot be reused"
+  // error that a shared stateless transport throws on its second request, and
+  // keeps concurrent clients fully isolated. n8n opens a new request per call.
+  app.post('/mcp', authMiddleware, async (req, res) => {
+    const mcpServer = buildMcpServer();
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+
+    res.on('close', () => {
+      void transport.close();
+      void mcpServer.close();
+    });
+
+    try {
+      await mcpServer.connect(transport);
+      await transport.handleRequest(req, res, undefined);
+    } catch (err) {
+      console.error('MCP transport error:', err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: (err as Error).message });
+      }
+    }
+  });
+
+  return { app, services };
+}

--- a/refactor/src/auth/github-app.test.ts
+++ b/refactor/src/auth/github-app.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GitHubAppAuth } from './github-app.js';
+
+/**
+ * Builds a mock App-authorized Octokit-like object whose `auth()` returns
+ * installation tokens and whose `rest.apps.getRepoInstallation` returns an
+ * installation id.
+ */
+function makeMockAppOctokit(installationId: number) {
+  let callCount = 0;
+  const callsByInstall: Record<number, number> = {};
+  // Track the most recently minted token per installation so caching tests
+  // can assert idempotency while expiry tests see a fresh token on remint.
+  const lastMintByInstall: Record<number, { token: string; expiresAt: string }> = {};
+  const mintFresh = (id: number) => {
+    callCount += 1;
+    callsByInstall[id] = (callsByInstall[id] ?? 0) + 1;
+    const mint = {
+      token: `ghs_inst_${id}_v${callsByInstall[id]}`,
+      expiresAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+    };
+    lastMintByInstall[id] = mint;
+    return mint;
+  };
+  const auth = vi.fn(async (opts: { type: string; installationId?: number }) => {
+    if (opts.type !== 'installation' || opts.installationId === undefined) {
+      throw new Error(`unexpected auth type: ${opts.type}`);
+    }
+    const id = opts.installationId;
+    const mint = mintFresh(id);
+    return { token: mint.token, expiresAt: mint.expiresAt, installationId: id };
+  });
+
+  const api = {
+    auth,
+    rest: {
+      apps: {
+        getRepoInstallation: vi.fn(async ({ owner, repo }: { owner: string; repo: string }) => ({
+          data: { id: installationId, ...(owner ? {} : {}) },
+        })),
+      },
+    },
+    getTokenCalls: (id: number) => callsByInstall[id] ?? 0,
+  };
+  return api;
+}
+
+describe('GitHubAppAuth', () => {
+  it('mints an installation token and returns an Octokit-ready token', async () => {
+    const mock = makeMockAppOctokit(4242);
+    const auth = new GitHubAppAuth({
+      appId: '111',
+      privateKey: 'pk',
+      appOctokit: mock as unknown as never,
+    });
+    const result = await auth.getInstallationToken('octocat', 'Hello-World');
+    expect(result.installationId).toBe(4242);
+    expect(result.token).toMatch(/^ghs_inst_4242/);
+    expect(mock.rest.apps.getRepoInstallation).toHaveBeenCalledWith({
+      owner: 'octocat',
+      repo: 'Hello-World',
+    });
+  });
+
+  it('caches the installation id by owner/repo', async () => {
+    const mock = makeMockAppOctokit(7);
+    const auth = new GitHubAppAuth({
+      appId: '1',
+      privateKey: 'k',
+      appOctokit: mock as unknown as never,
+    });
+    await auth.getInstallationToken('a', 'b');
+    await auth.getInstallationToken('a', 'b');
+    expect(mock.rest.apps.getRepoInstallation).toHaveBeenCalledTimes(1);
+  });
+
+  it('caches the token within its TTL', async () => {
+    const mock = makeMockAppOctokit(9);
+    const auth = new GitHubAppAuth({
+      appId: '1',
+      privateKey: 'k',
+      appOctokit: mock as unknown as never,
+    });
+    await auth.getInstallationToken('a', 'b');
+    await auth.getInstallationToken('a', 'b');
+    // internal auth() should have minted only once while in TTL
+    expect(mock.auth).toHaveBeenCalledTimes(1);
+  });
+
+  it('refreshes the token after expiry', async () => {
+    const mock = makeMockAppOctokit(13);
+    const auth = new GitHubAppAuth({
+      appId: '1',
+      privateKey: 'k',
+      appOctokit: mock as unknown as never,
+    });
+    const first = await auth.getInstallationToken('a', 'b');
+    expect(first.token).toBe('ghs_inst_13_v1');
+    // Advance time past expiry
+    const originalNow = Date.now;
+    Date.now = () => new Date(first.expiresAt).getTime() + 10 * 60 * 1000;
+    try {
+      const second = await auth.getInstallationToken('a', 'b');
+      expect(second.token).not.toBe(first.token);
+    } finally {
+      Date.now = originalNow;
+    }
+  });
+
+  it('surfaces a clear error when the installation is not found', async () => {
+    const mock = {
+      auth: vi.fn(async () => ({ token: 'x', expiresAt: 'x' })),
+      rest: {
+        apps: {
+          getRepoInstallation: vi.fn(async () => {
+            const err = new Error('Could not resolve installation');
+            (err as Error & { status: number }).status = 404;
+            throw err;
+          }),
+        },
+      },
+    };
+    const auth = new GitHubAppAuth({
+      appId: '1',
+      privateKey: 'k',
+      appOctokit: mock as unknown as never,
+    });
+    await expect(auth.getInstallationToken('nope', 'nada')).rejects.toThrow(
+      /installation/i,
+    );
+  });
+
+  it('clearCache resets cached tokens', async () => {
+    const mock = makeMockAppOctokit(21);
+    const auth = new GitHubAppAuth({
+      appId: '1',
+      privateKey: 'k',
+      appOctokit: mock as unknown as never,
+    });
+    await auth.getInstallationToken('a', 'b');
+    auth.clearCache();
+    await auth.getInstallationToken('a', 'b');
+    expect(mock.auth).toHaveBeenCalledTimes(2);
+  });
+});

--- a/refactor/src/auth/github-app.ts
+++ b/refactor/src/auth/github-app.ts
@@ -1,0 +1,144 @@
+/**
+ * GitHub App authentication: mints and caches short-lived installation tokens
+ * for `{ owner, repo }`, returning an Octokit-ready token / Octokit instance.
+ *
+ * Auth uses `@octokit/auth-app`. The App-authorized Octokit (created via
+ * `createAppAuth`) is injected so the module is trivially testable with a
+ * mock. See `createAppOctokit` for production construction.
+ */
+import { Octokit } from '@octokit/rest';
+import { createAppAuth } from '@octokit/auth-app';
+import type { IGitHubAppAuth } from '../types/index.js';
+
+/** Hour before expiry at which we proactively refresh. */
+const REFRESH_BUFFER_MS = 5 * 60 * 1000;
+
+/** Minimal App-authorized Octokit surface used internally. */
+interface AppOctokitLike {
+  auth(opts: { type: 'installation'; installationId: number }): Promise<{
+    token: string;
+    expiresAt: string;
+    installationId: number;
+  }>;
+  rest: {
+    apps: {
+      getRepoInstallation(params: { owner: string; repo: string }): Promise<{
+        data: { id: number };
+      }>;
+    };
+  };
+}
+
+interface CachedToken {
+  token: string;
+  expiresAt: string;
+  installationId: number;
+}
+
+export interface GitHubAppAuthCtor {
+  appId: string;
+  privateKey: string;
+  /** Inject for tests; otherwise built via `createAppAuth`. */
+  appOctokit?: AppOctokitLike;
+}
+
+/**
+ * Mints installation-scoped tokens and Octokit instances for repositories.
+ *
+ * Tokens are cached per installation id and refreshed before expiry. The
+ * `owner/repo → installationId` lookup is cached per process.
+ */
+export class GitHubAppAuth implements IGitHubAppAuth {
+  private readonly appOctokit: AppOctokitLike;
+  private readonly installationByRepo = new Map<string, number>();
+  private readonly tokenByInstallation = new Map<number, CachedToken>();
+
+  constructor(deps: GitHubAppAuthCtor) {
+    this.appOctokit =
+      deps.appOctokit ??
+      (createAppOctokit(deps.appId, deps.privateKey) as unknown as AppOctokitLike);
+  }
+
+  /**
+   * Resolves an installation-scoped token for `{ owner, repo }`, minting or
+   * refreshing from cache as needed.
+   */
+  async getInstallationToken(
+    owner: string,
+    repo: string,
+  ): Promise<CachedToken> {
+    const installationId = await this.resolveInstallationId(owner, repo);
+    return this.getOrRefreshToken(installationId);
+  }
+
+  /** Injects tokens into Octokit instances authenticated as the installation. */
+  async getInstallationOctokit(owner: string, repo: string): Promise<Octokit> {
+    const { token } = await this.getInstallationToken(owner, repo);
+    return new Octokit({ auth: token });
+  }
+
+  /** Clears installation-id and token caches (test helper). */
+  clearCache(): void {
+    this.installationByRepo.clear();
+    this.tokenByInstallation.clear();
+  }
+
+  private async resolveInstallationId(
+    owner: string,
+    repo: string,
+  ): Promise<number> {
+    const key = `${owner}/${repo}`.toLowerCase();
+    const cached = this.installationByRepo.get(key);
+    if (cached !== undefined) return cached;
+
+    let data: { id: number };
+    try {
+      ({ data } = await this.appOctokit.rest.apps.getRepoInstallation({
+        owner,
+        repo,
+      }));
+    } catch (err) {
+      const status = (err as Error & { status?: number }).status;
+      throw new Error(
+        `GitHub installation not found for ${owner}/${repo}` +
+          (status ? ` (HTTP ${status})` : '') +
+          '. Confirm the GitHub App is installed on this repository.',
+      );
+    }
+    this.installationByRepo.set(key, data.id);
+    return data.id;
+  }
+
+  private async getOrRefreshToken(
+    installationId: number,
+  ): Promise<CachedToken> {
+    const cached = this.tokenByInstallation.get(installationId);
+    if (cached && this.isFresh(cached)) {
+      return cached;
+    }
+    const { token, expiresAt } = await this.appOctokit.auth({
+      type: 'installation',
+      installationId,
+    });
+    const value: CachedToken = { token, expiresAt, installationId };
+    this.tokenByInstallation.set(installationId, value);
+    return value;
+  }
+
+  private isFresh(cached: CachedToken): boolean {
+    const expiryMs = Date.parse(cached.expiresAt);
+    if (!Number.isFinite(expiryMs)) return false;
+    return Date.now() < expiryMs - REFRESH_BUFFER_MS;
+  }
+}
+
+/**
+ * Constructs the App-authorized Octokit used by production code. Exposed for
+ * test runners that want to mirror the real `createAppAuth` wiring.
+ */
+export function createAppOctokit(appId: string, privateKey: string): Octokit {
+  return new Octokit({
+    authStrategy: createAppAuth,
+    auth: { appId, privateKey },
+  });
+}

--- a/refactor/src/integration.test.ts
+++ b/refactor/src/integration.test.ts
@@ -146,7 +146,6 @@ describe('MCP server integration', () => {
       name: 'get_review_strategy',
       arguments: { owner: 'octo', repo: 'repo' },
     });
-    console.log('get_review_strategy status:', status, 'body:', body.substring(0, 500));
     expect(status).toBe(200);
     const result = parseSseResult(body) as any;
     expect(result).not.toBeNull();
@@ -188,7 +187,6 @@ describe('MCP server integration', () => {
       name: 'nonexistent_tool',
       arguments: {},
     });
-    console.log('unknown tool status:', status, 'body:', body.substring(0, 500));
     expect(status).toBe(200);
     const result = parseSseResult(body) as any;
     expect(result.isError).toBe(true);

--- a/refactor/src/integration.test.ts
+++ b/refactor/src/integration.test.ts
@@ -1,0 +1,202 @@
+/**
+ * End-to-end integration test for the MCP server.
+ *
+ * Boots the Express app (with mocked services) on a random port and makes
+ * raw HTTP POST requests to /mcp, parsing the SSE response. This avoids
+ * depending on the SDK's StreamableHTTPClientTransport internals.
+ */
+
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import http from 'node:http';
+import { createApp } from '../src/app.js';
+import { ConfigService } from '../src/services/config.js';
+import { GitHubAppAuth } from '../src/auth/github-app.js';
+import { StrategyService } from '../src/services/strategy.js';
+
+// ---- Mock services ----
+
+const MOCK_API_SECRET = 'test-secret-123';
+
+function makeMockConfig(): ConfigService {
+  return new ConfigService();
+}
+
+function makeMockGitHubApp(): GitHubAppAuth {
+  return {
+    getInstallationOctokit: vi.fn(async () => ({
+      rest: {
+        pulls: { get: vi.fn(), listFiles: vi.fn(), listCommits: vi.fn(), listReviews: vi.fn(), createReview: vi.fn() },
+        repos: { get: vi.fn(), getContent: vi.fn(), listLanguages: vi.fn(), getReadme: vi.fn() },
+        compareCommits: vi.fn(),
+      },
+    })),
+    clearCache: vi.fn(),
+  } as unknown as GitHubAppAuth;
+}
+
+function makeMockStrategy(): StrategyService {
+  return {
+    getCatalog: vi.fn(() => new Map()),
+    resolveForRepo: vi.fn(async (_octokit: any, _owner: string, _repo: string, _requested?: string) => ({
+      strategies: [{ name: 'full-review', description: 'Full review', body: 'Review everything.' }],
+      notice: 'Using default strategy (full-review).',
+    })),
+  } as unknown as StrategyService;
+}
+
+/** Send a JSON-RPC request to /mcp and return the parsed SSE body. */
+async function mcpRequest(
+  port: number,
+  method: string,
+  params: Record<string, unknown> = {},
+  apiKey = MOCK_API_SECRET,
+): Promise<{ status: number; body: string }> {
+  const body = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+  return new Promise((resolve, reject) => {
+    const options = {
+      hostname: 'localhost',
+      port,
+      path: '/mcp',
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': apiKey,
+        Accept: 'application/json, text/event-stream',
+        'Content-Length': Buffer.byteLength(body),
+      },
+    };
+    const req = http.request(options, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => resolve({ status: res.statusCode ?? 0, body: data }));
+    });
+    req.on('error', reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+/** Extract the JSON payload from an SSE `event: message` line. */
+function parseSseResult(sseBody: string): unknown {
+  for (const line of sseBody.split('\n')) {
+    if (line.startsWith('data: ')) {
+      try {
+        const parsed = JSON.parse(line.slice(6));
+        return (parsed as any).result;
+      } catch {
+        // continue
+      }
+    }
+  }
+  return null;
+}
+
+// ---- Test ----
+
+describe('MCP server integration', () => {
+  let app: ReturnType<typeof createApp>;
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    app = createApp({
+      config: makeMockConfig(),
+      githubApp: makeMockGitHubApp(),
+      strategy: makeMockStrategy(),
+      mcpApiSecret: MOCK_API_SECRET,
+    });
+
+    await new Promise<void>((resolve) => {
+      server = app.app.listen(0, () => {
+        port = (server.address() as any).port;
+        resolve();
+      });
+    });
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  it('discovers all 14 tools via listTools', async () => {
+    const { status, body } = await mcpRequest(port, 'tools/list');
+    expect(status).toBe(200);
+    const result = parseSseResult(body) as any;
+    expect(result).not.toBeNull();
+    expect(result.tools).toHaveLength(14);
+    const names = result.tools.map((t: any) => t.name);
+    expect(names).toContain('get_review_strategy');
+    expect(names).toContain('get_pr_details');
+    expect(names).toContain('get_pr_files');
+    expect(names).toContain('get_pr_commits');
+    expect(names).toContain('get_file_content');
+    expect(names).toContain('get_repo_info');
+    expect(names).toContain('get_pr_diff_range');
+    expect(names).toContain('post_pr_review');
+    expect(names).toContain('analyze_code_quality');
+    expect(names).toContain('analyze_diff_impact');
+    expect(names).toContain('analyze_dependencies');
+    expect(names).toContain('analyze_test_coverage');
+    expect(names).toContain('detect_security_issues');
+    expect(names).toContain('detect_code_patterns');
+  });
+
+  it('get_review_strategy returns strategy prompt', async () => {
+    const { status, body } = await mcpRequest(port, 'tools/call', {
+      name: 'get_review_strategy',
+      arguments: { owner: 'octo', repo: 'repo' },
+    });
+    console.log('get_review_strategy status:', status, 'body:', body.substring(0, 500));
+    expect(status).toBe(200);
+    const result = parseSseResult(body) as any;
+    expect(result).not.toBeNull();
+    const text = result.content[0].text;
+    expect(text).toContain('full-review');
+    expect(text).toContain('Using default strategy');
+  });
+
+  it('get_pr_details enforces allowlist', async () => {
+    const denyConfig = makeMockConfig();
+    vi.spyOn(denyConfig, 'isRepoAllowed').mockReturnValue(false);
+
+    const denyApp = createApp({
+      config: denyConfig,
+      githubApp: makeMockGitHubApp(),
+      strategy: makeMockStrategy(),
+      mcpApiSecret: MOCK_API_SECRET,
+    });
+
+    const denyServer = await new Promise<any>((resolve) => {
+      const s = denyApp.app.listen(0, () => resolve(s));
+    });
+    const denyPort = (denyServer.address() as any).port;
+
+    const { status, body } = await mcpRequest(denyPort, 'tools/call', {
+      name: 'get_pr_details',
+      arguments: { pr_url: 'https://github.com/octo/repo/pull/42' },
+    });
+    expect(status).toBe(200);
+    const result = parseSseResult(body) as any;
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/allowlist/i);
+
+    await new Promise<void>((resolve) => denyServer.close(() => resolve()));
+  });
+
+  it('returns error for unknown tool', async () => {
+    const { status, body } = await mcpRequest(port, 'tools/call', {
+      name: 'nonexistent_tool',
+      arguments: {},
+    });
+    console.log('unknown tool status:', status, 'body:', body.substring(0, 500));
+    expect(status).toBe(200);
+    const result = parseSseResult(body) as any;
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain('Unknown tool');
+  });
+
+  it('rejects requests without auth header', async () => {
+    const { status } = await mcpRequest(port, 'tools/list', {}, 'wrong-key');
+    expect(status).toBe(401);
+  });
+});

--- a/refactor/src/server.ts
+++ b/refactor/src/server.ts
@@ -1,134 +1,19 @@
 /**
- * MCP server entrypoint — bootstraps the Streamable HTTP MCP server with
- * header-secret auth, rate limiting, and the tool registry.
+ * MCP server entrypoint — bootstraps the Streamable HTTP MCP server.
  *
  * Usage:
  *   MCP_API_SECRET=... GITHUB_APP_ID=... GITHUB_APP_PRIVATE_KEY=... \
  *     tsx src/server.ts
- *
- * The server exposes:
- *   - GET  /health          → { status: "ok", version }
- *   - POST /mcp             → MCP Streamable HTTP transport (ListTools, CallTool)
- *   - All other routes      → 404
  */
 
 import 'dotenv/config';
-import express from 'express';
-import rateLimit from 'express-rate-limit';
-import { Server } from '@modelcontextprotocol/sdk/server/index.js';
-import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
-import {
-  ListToolsRequestSchema,
-  CallToolRequestSchema,
-} from '@modelcontextprotocol/sdk/types.js';
-import { ConfigService } from './services/config.js';
-import { GitHubAppAuth, createAppOctokit } from './auth/github-app.js';
-import { StrategyService } from './services/strategy.js';
-import { registerAllTools, getTool, toolDefinitions } from './tools/index.js';
-import type { ToolServices } from './types/index.js';
+import { createApp } from './app.js';
 
-// ---- Bootstrap services ----
+const { app } = createApp();
 
-const config = new ConfigService();
-const appOctokit = createAppOctokit(config.githubAppId, config.githubAppPrivateKey);
-const githubApp = new GitHubAppAuth({
-  appId: config.githubAppId,
-  privateKey: config.githubAppPrivateKey,
-  appOctokit: appOctokit as never,
-});
-const strategy = new StrategyService();
-
-const services: ToolServices = { config, githubApp, strategy };
-
-// ---- Register all tools ----
-
-registerAllTools();
-
-// ---- Create MCP Server ----
-
-const mcpServer = new Server(
-  { name: 'github-review-mcp', version: '0.1.0' },
-  { capabilities: { tools: {} } },
-);
-
-// ListTools handler
-mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
-  tools: toolDefinitions,
-}));
-
-// CallTool handler
-mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
-  const { name, arguments: args } = request.params;
-  const entry = getTool(name);
-  if (!entry) {
-    return {
-      content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
-      isError: true,
-    };
-  }
-  return entry.handler(args ?? {}, services) as never;
-});
-
-// ---- Express app ----
-
-const app = express();
-
-// Trust proxy for rate limiting behind reverse proxies
-app.set('trust proxy', 1);
-
-// Rate limiting
-const limiter = rateLimit({
-  windowMs: 60_000,
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: 'Too many requests, please try again later.' },
-});
-app.use(limiter);
-
-// Header-secret auth middleware (applied to /mcp)
-function authMiddleware(
-  req: express.Request,
-  res: express.Response,
-  next: express.NextFunction,
-): void {
-  const provided = req.headers['x-api-key'] as string | undefined;
-  if (!provided || provided !== config.mcpApiSecret) {
-    res.status(401).json({ error: 'Unauthorized: invalid or missing x-api-key header' });
-    return;
-  }
-  next();
-}
-
-// Health endpoint (no auth)
-app.get('/health', (_req, res) => {
-  res.json({ status: 'ok', version: '0.1.0' });
-});
-
-// MCP transport — one instance per server (stateless, session managed by SDK)
-const transport = new StreamableHTTPServerTransport({});
-
-// Connect the MCP server to the transport (SDK wires onmessage internally)
-await mcpServer.connect(transport);
-
-app.post('/mcp', authMiddleware, express.json(), async (req, res) => {
-  try {
-    await transport.handleRequest(req, res, req.body);
-  } catch (err) {
-    if (!res.headersSent) {
-      res.status(500).json({ error: (err as Error).message });
-    }
-  }
-});
-
-// ---- Start ----
-
-const port = config.port;
+const port = Number(process.env.PORT) || 3000;
 app.listen(port, () => {
   console.log(`github-review-mcp server listening on port ${port}`);
   console.log(`  Health:  http://localhost:${port}/health`);
   console.log(`  MCP:     POST http://localhost:${port}/mcp (x-api-key header)`);
-  console.log(`  Tools:   ${toolDefinitions.length} registered`);
 });
-
-export { app, mcpServer, transport, services };

--- a/refactor/src/server.ts
+++ b/refactor/src/server.ts
@@ -1,0 +1,7 @@
+/**
+ * MCP server entrypoint (stub — implemented in Phase 5).
+ *
+ * Bootstraps the Streamable HTTP MCP server with header-secret auth,
+ * rate limiting, and the tool registry.
+ */
+export {};

--- a/refactor/src/server.ts
+++ b/refactor/src/server.ts
@@ -1,7 +1,134 @@
 /**
- * MCP server entrypoint (stub — implemented in Phase 5).
+ * MCP server entrypoint — bootstraps the Streamable HTTP MCP server with
+ * header-secret auth, rate limiting, and the tool registry.
  *
- * Bootstraps the Streamable HTTP MCP server with header-secret auth,
- * rate limiting, and the tool registry.
+ * Usage:
+ *   MCP_API_SECRET=... GITHUB_APP_ID=... GITHUB_APP_PRIVATE_KEY=... \
+ *     tsx src/server.ts
+ *
+ * The server exposes:
+ *   - GET  /health          → { status: "ok", version }
+ *   - POST /mcp             → MCP Streamable HTTP transport (ListTools, CallTool)
+ *   - All other routes      → 404
  */
-export {};
+
+import 'dotenv/config';
+import express from 'express';
+import rateLimit from 'express-rate-limit';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import {
+  ListToolsRequestSchema,
+  CallToolRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { ConfigService } from './services/config.js';
+import { GitHubAppAuth, createAppOctokit } from './auth/github-app.js';
+import { StrategyService } from './services/strategy.js';
+import { registerAllTools, getTool, toolDefinitions } from './tools/index.js';
+import type { ToolServices } from './types/index.js';
+
+// ---- Bootstrap services ----
+
+const config = new ConfigService();
+const appOctokit = createAppOctokit(config.githubAppId, config.githubAppPrivateKey);
+const githubApp = new GitHubAppAuth({
+  appId: config.githubAppId,
+  privateKey: config.githubAppPrivateKey,
+  appOctokit: appOctokit as never,
+});
+const strategy = new StrategyService();
+
+const services: ToolServices = { config, githubApp, strategy };
+
+// ---- Register all tools ----
+
+registerAllTools();
+
+// ---- Create MCP Server ----
+
+const mcpServer = new Server(
+  { name: 'github-review-mcp', version: '0.1.0' },
+  { capabilities: { tools: {} } },
+);
+
+// ListTools handler
+mcpServer.setRequestHandler(ListToolsRequestSchema, async () => ({
+  tools: toolDefinitions,
+}));
+
+// CallTool handler
+mcpServer.setRequestHandler(CallToolRequestSchema, async (request) => {
+  const { name, arguments: args } = request.params;
+  const entry = getTool(name);
+  if (!entry) {
+    return {
+      content: [{ type: 'text' as const, text: `Unknown tool: ${name}` }],
+      isError: true,
+    };
+  }
+  return entry.handler(args ?? {}, services) as never;
+});
+
+// ---- Express app ----
+
+const app = express();
+
+// Trust proxy for rate limiting behind reverse proxies
+app.set('trust proxy', 1);
+
+// Rate limiting
+const limiter = rateLimit({
+  windowMs: 60_000,
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: 'Too many requests, please try again later.' },
+});
+app.use(limiter);
+
+// Header-secret auth middleware (applied to /mcp)
+function authMiddleware(
+  req: express.Request,
+  res: express.Response,
+  next: express.NextFunction,
+): void {
+  const provided = req.headers['x-api-key'] as string | undefined;
+  if (!provided || provided !== config.mcpApiSecret) {
+    res.status(401).json({ error: 'Unauthorized: invalid or missing x-api-key header' });
+    return;
+  }
+  next();
+}
+
+// Health endpoint (no auth)
+app.get('/health', (_req, res) => {
+  res.json({ status: 'ok', version: '0.1.0' });
+});
+
+// MCP transport — one instance per server (stateless, session managed by SDK)
+const transport = new StreamableHTTPServerTransport({});
+
+// Connect the MCP server to the transport (SDK wires onmessage internally)
+await mcpServer.connect(transport);
+
+app.post('/mcp', authMiddleware, express.json(), async (req, res) => {
+  try {
+    await transport.handleRequest(req, res, req.body);
+  } catch (err) {
+    if (!res.headersSent) {
+      res.status(500).json({ error: (err as Error).message });
+    }
+  }
+});
+
+// ---- Start ----
+
+const port = config.port;
+app.listen(port, () => {
+  console.log(`github-review-mcp server listening on port ${port}`);
+  console.log(`  Health:  http://localhost:${port}/health`);
+  console.log(`  MCP:     POST http://localhost:${port}/mcp (x-api-key header)`);
+  console.log(`  Tools:   ${toolDefinitions.length} registered`);
+});
+
+export { app, mcpServer, transport, services };

--- a/refactor/src/services/__fixtures__/empty-body-catalog/empty.md
+++ b/refactor/src/services/__fixtures__/empty-body-catalog/empty.md
@@ -1,0 +1,4 @@
+---
+name: empty
+description: no body strategy
+---

--- a/refactor/src/services/__fixtures__/malformed-catalog/bad.md
+++ b/refactor/src/services/__fixtures__/malformed-catalog/bad.md
@@ -1,0 +1,7 @@
+---
+name: broken
+description: [this is : : broken yaml
+  - unterminated
+---
+
+Body here.

--- a/refactor/src/services/__fixtures__/strategies-catalog-clean/performance.md
+++ b/refactor/src/services/__fixtures__/strategies-catalog-clean/performance.md
@@ -1,0 +1,7 @@
+---
+name: performance
+description: perf review
+---
+
+# Perf
+Body.

--- a/refactor/src/services/__fixtures__/strategies-catalog-clean/security.md
+++ b/refactor/src/services/__fixtures__/strategies-catalog-clean/security.md
@@ -1,0 +1,10 @@
+---
+name: security
+description: security review
+triggers:
+  - secrets
+priority: 2
+---
+
+# Security
+Body text.

--- a/refactor/src/services/__fixtures__/strategies-clean/performance.md
+++ b/refactor/src/services/__fixtures__/strategies-clean/performance.md
@@ -1,0 +1,7 @@
+---
+name: performance
+description: perf review
+---
+
+# Perf
+Body.

--- a/refactor/src/services/__fixtures__/strategies-clean/security.md
+++ b/refactor/src/services/__fixtures__/strategies-clean/security.md
@@ -1,0 +1,10 @@
+---
+name: security
+description: security review
+triggers:
+  - secrets
+priority: 2
+---
+
+# Security
+Body text.

--- a/refactor/src/services/__fixtures__/strategies-resolve-clean/full-review.md
+++ b/refactor/src/services/__fixtures__/strategies-resolve-clean/full-review.md
@@ -1,0 +1,7 @@
+---
+name: full-review
+description: full review
+---
+
+# Full
+body.

--- a/refactor/src/services/__fixtures__/strategies-resolve-clean/performance.md
+++ b/refactor/src/services/__fixtures__/strategies-resolve-clean/performance.md
@@ -1,0 +1,7 @@
+---
+name: performance
+description: perf review
+---
+
+# Perf
+body.

--- a/refactor/src/services/__fixtures__/strategies-resolve-clean/security.md
+++ b/refactor/src/services/__fixtures__/strategies-resolve-clean/security.md
@@ -1,0 +1,7 @@
+---
+name: security
+description: security review
+---
+
+# Security
+body.

--- a/refactor/src/services/__fixtures__/strategies/dup-a.md
+++ b/refactor/src/services/__fixtures__/strategies/dup-a.md
@@ -1,0 +1,6 @@
+---
+name: security
+description: duplicate name fixture
+---
+
+Duplicate of security.md.

--- a/refactor/src/services/__fixtures__/strategies/performance.md
+++ b/refactor/src/services/__fixtures__/strategies/performance.md
@@ -1,0 +1,8 @@
+---
+name: performance
+description: Performance and efficiency focused review
+---
+
+# Performance Review Strategy
+
+Review for algorithmic efficiency and resource usage.

--- a/refactor/src/services/__fixtures__/strategies/security.md
+++ b/refactor/src/services/__fixtures__/strategies/security.md
@@ -1,0 +1,13 @@
+---
+name: security
+description: Focused security vulnerability and input-validation review
+triggers:
+  - pr_with_secrets
+  - dependency_changes
+priority: 2
+---
+
+# Security Review Strategy
+
+You are reviewing this PR for security issues. Focus on input validation
+and authentication boundaries.

--- a/refactor/src/services/analysis.ts
+++ b/refactor/src/services/analysis.ts
@@ -1,0 +1,661 @@
+/**
+ * AnalysisService — data-only heuristic analysis of PR changes.
+ *
+ * Ported faithfully from the legacy `src/services/analysis.js`, but strictly
+ * DATA-ONLY: no LLM, no network. Every method derives structured findings
+ * from PR file patches using regexes and simple math, so tool handlers can
+ * return objective signal for an external agent to reason over.
+ *
+ * The service is stateless beyond its precomputed pattern tables, so tool
+ * handlers may freely `new AnalysisService()` per call.
+ */
+
+import type { PRDetails, PRFile } from '../types/index.js';
+
+type Severity = 'critical' | 'high' | 'medium' | 'low';
+
+export interface FileQuality {
+  filename: string;
+  language: string;
+  metrics: {
+    cyclomatic_complexity: number;
+    lines_of_code: number;
+    maintainability_index: number;
+    technical_debt_ratio: number;
+  };
+  issues: Array<{ type: string; severity: string; description: string }>;
+  suggestions: Array<{ type: string; description: string; priority: string }>;
+}
+
+export interface CodeQualityResult {
+  overall_score: number;
+  files: FileQuality[];
+  summary: {
+    high_complexity_files: Array<{ filename: string; complexity: number }>;
+    maintainability_issues: Array<{ filename: string; score: number }>;
+    code_smells: Array<{ filename: string; debt_ratio: number }>;
+    recommendations: string[];
+  };
+}
+
+export interface DiffImpactResult {
+  overall_risk: 'LOW' | 'MEDIUM' | 'HIGH';
+  impact_categories: Record<string, string[]>;
+  risk_factors: string[];
+  affected_areas: string[];
+  recommendations: string[];
+}
+
+export interface SecurityResult {
+  security_score: number;
+  vulnerabilities: Array<{
+    type: string;
+    file: string;
+    severity: Severity;
+    description: string;
+  }>;
+  warnings: unknown[];
+  best_practices: unknown[];
+  compliance_issues: unknown[];
+}
+
+export interface CodePatternsResult {
+  patterns_found: {
+    good_patterns: Array<{ name: string; file: string; description: string }>;
+    anti_patterns: Array<{ name: string; file: string; description: string }>;
+    architectural_issues: unknown[];
+    design_patterns: unknown[];
+  };
+  recommendations: string[];
+  language: string;
+}
+
+export interface DependenciesResult {
+  dependency_changes: {
+    added: unknown[];
+    removed: unknown[];
+    updated: unknown[];
+    security_issues: unknown[];
+  };
+  impact_assessment: {
+    risk_level: 'LOW' | 'MEDIUM' | 'HIGH';
+    compatibility_issues: unknown[];
+    security_implications: unknown[];
+    performance_impact: unknown[];
+  };
+  recommendations: string[];
+}
+
+export interface TestCoverageResult {
+  coverage_estimate: number;
+  test_files: PRFile[];
+  production_files: PRFile[];
+  missing_tests: Array<{ filename: string; suggested_test_file: string }>;
+  test_quality: {
+    unit_tests: number;
+    integration_tests: number;
+    edge_cases: number;
+  };
+  recommendations: string[];
+}
+
+const SECURITY_PATTERNS: Record<string, RegExp[]> = {
+  sql_injection: [/query\s*\+.*\+/gi, /execute\s*\(.*\+.*\)/gi, /SELECT.*\+.*FROM/gi],
+  xss: [/innerHTML\s*=.*\+/gi, /document\.write\s*\(/gi, /\.html\s*\(.*\+/gi],
+  hardcoded_secrets: [
+    /password\s*=\s*["'][^"']+["']/gi,
+    /api_key\s*=\s*["'][^"']+["']/gi,
+    /secret\s*=\s*["'][^"']+["']/gi,
+    /token\s*=\s*["'][^"']+["']/gi,
+  ],
+  insecure_random: [/Math\.random\(\)/gi, /rand\(\)/gi],
+  eval_usage: [/eval\s*\(/gi, /exec\s*\(/gi, /setTimeout\s*\(.*string/gi],
+};
+
+interface NamedPattern {
+  name: string;
+  pattern: RegExp;
+  description: string;
+}
+
+const ANTI_PATTERNS: NamedPattern[] = [
+  { name: 'God Object', pattern: /class\s+\w+[\s\S]{1000,}/gi, description: 'Large classes that do too much' },
+  { name: 'Magic Numbers', pattern: /[^.\w]\d{2,}[^.\w]/g, description: 'Hardcoded numeric values without explanation' },
+  { name: 'Long Parameter List', pattern: /function\s+\w+\s*\([^)]{80,}\)/gi, description: 'Functions with too many parameters' },
+];
+
+const GOOD_PATTERNS: NamedPattern[] = [
+  { name: 'Single Responsibility', pattern: /class\s+\w+[\s\S]{50,200}/gi, description: 'Appropriately sized classes' },
+  { name: 'Constants Usage', pattern: /const\s+[A-Z_]+\s*=/gi, description: 'Use of constants instead of magic numbers' },
+];
+
+const DEPENDENCY_PACKAGE_FILES = [
+  'package.json',
+  'requirements.txt',
+  'Gemfile',
+  'pom.xml',
+  'Cargo.toml',
+  'go.mod',
+  'composer.json',
+];
+const DEPENDENCY_LOCK_FILES = [
+  'package-lock.json',
+  'yarn.lock',
+  'Pipfile.lock',
+  'Gemfile.lock',
+  'Cargo.lock',
+  'go.sum',
+];
+
+export class AnalysisService {
+  analyzeCodeQuality(prDetails: PRDetails, filePaths: string[] | null = null): CodeQualityResult {
+    const files: FileQuality[] = [];
+    for (const file of prDetails.files) {
+      if (filePaths && !filePaths.includes(file.filename)) continue;
+      files.push(this.analyzeFileQuality(file));
+    }
+    return {
+      overall_score: this.calculateOverallScore(files),
+      files,
+      summary: this.generateQualitySummary(files),
+    };
+  }
+
+  private analyzeFileQuality(file: PRFile): FileQuality {
+    const language = this.detectLanguage(file.filename);
+    const analysis: FileQuality = {
+      filename: file.filename,
+      language,
+      metrics: {
+        cyclomatic_complexity: 0,
+        lines_of_code: 0,
+        maintainability_index: 0,
+        technical_debt_ratio: 0,
+      },
+      issues: [],
+      suggestions: [],
+    };
+    if (!file.patch) return analysis;
+
+    const lines = file.patch.split('\n');
+    const addedLines = lines.filter((l) => l.startsWith('+')).slice(1);
+
+    analysis.metrics.lines_of_code = addedLines.length;
+    analysis.metrics.cyclomatic_complexity = this.calculateComplexity(addedLines, language);
+    analysis.metrics.maintainability_index = this.calculateMaintainabilityIndex(addedLines, language);
+    analysis.metrics.technical_debt_ratio = this.calculateTechnicalDebt(addedLines);
+    analysis.issues = this.detectCodeIssues(addedLines);
+    analysis.suggestions = this.generateCodeSuggestions(addedLines, language);
+    return analysis;
+  }
+
+  analyzeDiffImpact(prDetails: PRDetails): DiffImpactResult {
+    const analysis: DiffImpactResult = {
+      overall_risk: 'LOW',
+      impact_categories: {
+        breaking_changes: [],
+        api_changes: [],
+        database_changes: [],
+        configuration_changes: [],
+        security_sensitive: [],
+        performance_critical: [],
+      },
+      risk_factors: [],
+      affected_areas: [],
+      recommendations: [],
+    };
+    for (const file of prDetails.files) {
+      this.mergeImpactAnalysis(analysis, this.analyzeFileImpact(file));
+    }
+    analysis.overall_risk = this.calculateOverallRisk(analysis);
+    analysis.recommendations = this.generateImpactRecommendations(analysis);
+    return analysis;
+  }
+
+  detectSecurityIssues(prDetails: PRDetails): SecurityResult {
+    const analysis: SecurityResult = {
+      security_score: 100,
+      vulnerabilities: [],
+      warnings: [],
+      best_practices: [],
+      compliance_issues: [],
+    };
+    for (const file of prDetails.files) {
+      if (!file.patch) continue;
+      analysis.vulnerabilities.push(...this.scanFileForSecurity(file));
+    }
+    analysis.security_score = this.calculateSecurityScore(analysis);
+    return analysis;
+  }
+
+  detectCodePatterns(prDetails: PRDetails, language: string | null = null): CodePatternsResult {
+    const analysis: CodePatternsResult = {
+      patterns_found: {
+        good_patterns: [],
+        anti_patterns: [],
+        architectural_issues: [],
+        design_patterns: [],
+      },
+      recommendations: [],
+      language: language ?? this.detectPrimaryLanguage(prDetails.files),
+    };
+    for (const file of prDetails.files) {
+      if (!file.patch) continue;
+      const filePatterns = this.analyzeFilePatterns(file);
+      analysis.patterns_found.good_patterns.push(...filePatterns.good_patterns);
+      analysis.patterns_found.anti_patterns.push(...filePatterns.anti_patterns);
+    }
+    analysis.recommendations = this.generatePatternRecommendations(analysis);
+    return analysis;
+  }
+
+  analyzeDependencies(prDetails: PRDetails): DependenciesResult {
+    const analysis: DependenciesResult = {
+      dependency_changes: { added: [], removed: [], updated: [], security_issues: [] },
+      impact_assessment: {
+        risk_level: 'LOW',
+        compatibility_issues: [],
+        security_implications: [],
+        performance_impact: [],
+      },
+      recommendations: [],
+    };
+    const dependencyFiles = prDetails.files.filter((f) => this.isDependencyFile(f.filename));
+    analysis.recommendations = this.generateDependencyRecommendations(dependencyFiles.length);
+    return analysis;
+  }
+
+  analyzeTestCoverage(prDetails: PRDetails): TestCoverageResult {
+    const test_files: PRFile[] = [];
+    const production_files: PRFile[] = [];
+    for (const file of prDetails.files) {
+      if (this.isTestFile(file.filename)) test_files.push(file);
+      else if (this.isProductionFile(file.filename)) production_files.push(file);
+    }
+    const coverage_estimate = this.estimateTestCoverage(test_files, production_files);
+    const missing_tests = this.identifyMissingTests(production_files, test_files);
+    const test_quality = this.analyzeTestQuality(test_files);
+    const recommendations = this.generateTestRecommendations(coverage_estimate, missing_tests, test_quality);
+    return {
+      coverage_estimate,
+      test_files,
+      production_files,
+      missing_tests,
+      test_quality,
+      recommendations,
+    };
+  }
+
+  // ---- helpers ----
+
+  private detectLanguage(filename: string): string {
+    const extension = (filename.split('.').pop() ?? '').toLowerCase();
+    const languageMap: Record<string, string> = {
+      js: 'javascript',
+      jsx: 'javascript',
+      ts: 'typescript',
+      tsx: 'typescript',
+      py: 'python',
+      java: 'java',
+      go: 'go',
+      rs: 'rust',
+      cpp: 'cpp',
+      c: 'c',
+      cs: 'csharp',
+      php: 'php',
+      rb: 'ruby',
+      swift: 'swift',
+      kt: 'kotlin',
+    };
+    return languageMap[extension] ?? 'unknown';
+  }
+
+  private detectPrimaryLanguage(files: PRFile[]): string {
+    const counts: Record<string, number> = {};
+    for (const file of files) {
+      const lang = this.detectLanguage(file.filename);
+      counts[lang] = (counts[lang] ?? 0) + 1;
+    }
+    const sorted = Object.entries(counts).sort((a, b) => b[1] - a[1]);
+    return sorted[0]?.[0] ?? 'unknown';
+  }
+
+  private calculateComplexity(lines: string[], language: string): number {
+    let complexity = 1;
+    const complexityKeywords: Record<string, string[]> = {
+      javascript: ['if', 'else', 'while', 'for', 'switch', 'case', 'catch', '&&', '||', '?'],
+      typescript: ['if', 'else', 'while', 'for', 'switch', 'case', 'catch', '&&', '||', '?'],
+      python: ['if', 'elif', 'else', 'while', 'for', 'try', 'except', 'and', 'or'],
+      java: ['if', 'else', 'while', 'for', 'switch', 'case', 'catch', '&&', '||', '?'],
+    };
+    const keywords = complexityKeywords[language] ?? complexityKeywords.javascript;
+    for (const line of lines) {
+      const trimmed = line.replace(/^\+\s*/, '').trim();
+      for (const keyword of keywords) {
+        if (trimmed.includes(keyword)) complexity++;
+      }
+    }
+    return Math.min(complexity, 20);
+  }
+
+  private calculateMaintainabilityIndex(lines: string[], language: string): number {
+    const loc = lines.length;
+    const complexity = this.calculateComplexity(lines, language);
+    let maintainability = 100 - complexity * 2 - loc * 0.1;
+    const codeText = lines.join('\n');
+    if (codeText.includes('TODO') || codeText.includes('FIXME')) maintainability -= 5;
+    if (/\w{30,}/.test(codeText)) maintainability -= 3;
+    return Math.max(0, Math.min(100, maintainability));
+  }
+
+  private calculateTechnicalDebt(lines: string[]): number {
+    let debtScore = 0;
+    const codeText = lines.join('\n');
+    const debtIndicators = [
+      /TODO|FIXME|HACK|XXX/gi,
+      /console\.log|print\(|println!/gi,
+      /\/\*.*\*\//gs,
+      /\.length\s*>\s*\d{2,}/gi,
+      /function\s+\w+\([^)]{50,}\)/gi,
+      /if\s*\([^)]{50,}\)/gi,
+    ];
+    for (const pattern of debtIndicators) {
+      const matches = codeText.match(pattern);
+      if (matches) debtScore += matches.length * 5;
+    }
+    return Math.min(100, debtScore);
+  }
+
+  private calculateOverallScore(fileAnalyses: FileQuality[]): number {
+    if (fileAnalyses.length === 0) return 100;
+    const avg = (sel: (f: FileQuality) => number): number =>
+      fileAnalyses.reduce((sum, f) => sum + sel(f), 0) / fileAnalyses.length;
+    const avgMaintainability = avg((f) => f.metrics.maintainability_index);
+    const avgComplexity = avg((f) => f.metrics.cyclomatic_complexity);
+    const avgDebt = avg((f) => f.metrics.technical_debt_ratio);
+    return Math.round(avgMaintainability - avgComplexity * 2 - avgDebt * 0.5);
+  }
+
+  private generateQualitySummary(fileAnalyses: FileQuality[]): CodeQualityResult['summary'] {
+    const summary: CodeQualityResult['summary'] = {
+      high_complexity_files: [],
+      maintainability_issues: [],
+      code_smells: [],
+      recommendations: [],
+    };
+    for (const file of fileAnalyses) {
+      if (file.metrics.cyclomatic_complexity > 10) {
+        summary.high_complexity_files.push({
+          filename: file.filename,
+          complexity: file.metrics.cyclomatic_complexity,
+        });
+      }
+      if (file.metrics.maintainability_index < 60) {
+        summary.maintainability_issues.push({
+          filename: file.filename,
+          score: file.metrics.maintainability_index,
+        });
+      }
+      if (file.metrics.technical_debt_ratio > 20) {
+        summary.code_smells.push({
+          filename: file.filename,
+          debt_ratio: file.metrics.technical_debt_ratio,
+        });
+      }
+    }
+    if (summary.high_complexity_files.length > 0)
+      summary.recommendations.push('Consider breaking down complex functions into smaller, more manageable pieces');
+    if (summary.maintainability_issues.length > 0)
+      summary.recommendations.push('Focus on improving code readability and reducing complexity');
+    if (summary.code_smells.length > 0)
+      summary.recommendations.push('Address technical debt by removing TODO comments and cleaning up code');
+    return summary;
+  }
+
+  private detectCodeIssues(lines: string[]): FileQuality['issues'] {
+    const issues: FileQuality['issues'] = [];
+    const codeText = lines.join('\n');
+    if (/console\.log|print\(/gi.test(codeText)) {
+      issues.push({ type: 'debug_code', severity: 'medium', description: 'Debug statements found in code' });
+    }
+    if (/TODO|FIXME/gi.test(codeText)) {
+      issues.push({ type: 'incomplete_code', severity: 'low', description: 'TODO or FIXME comments found' });
+    }
+    return issues;
+  }
+
+  private generateCodeSuggestions(lines: string[], language: string): FileQuality['suggestions'] {
+    const suggestions: FileQuality['suggestions'] = [];
+    const codeText = lines.join('\n');
+    if (language === 'javascript' || language === 'typescript') {
+      if (codeText.includes('var ')) {
+        suggestions.push({ type: 'modernization', description: 'Consider using const/let instead of var', priority: 'medium' });
+      }
+      if (/function\s*\(/.test(codeText)) {
+        suggestions.push({ type: 'modernization', description: 'Consider using arrow functions for better readability', priority: 'low' });
+      }
+    }
+    return suggestions;
+  }
+
+  private analyzeFileImpact(file: PRFile): { filename: string; risk_level: string; categories: string[]; factors: string[] } {
+    const impact = { filename: file.filename, risk_level: 'LOW', categories: [] as string[], factors: [] as string[] };
+    if (file.filename.includes('config') || file.filename.includes('setting')) {
+      impact.categories.push('configuration_changes');
+      impact.risk_level = 'MEDIUM';
+    }
+    if (file.filename.includes('security') || file.filename.includes('auth')) {
+      impact.categories.push('security_sensitive');
+      impact.risk_level = 'HIGH';
+    }
+    if (file.status === 'removed') {
+      impact.factors.push('file_deletion');
+      impact.risk_level = 'HIGH';
+    }
+    return impact;
+  }
+
+  private mergeImpactAnalysis(
+    analysis: DiffImpactResult,
+    fileImpact: { filename: string; categories: string[]; factors: string[] },
+  ): void {
+    for (const category of fileImpact.categories) {
+      if (!analysis.impact_categories[category]) analysis.impact_categories[category] = [];
+      analysis.impact_categories[category].push(fileImpact.filename);
+    }
+    analysis.risk_factors.push(...fileImpact.factors);
+  }
+
+  private calculateOverallRisk(analysis: DiffImpactResult): 'LOW' | 'MEDIUM' | 'HIGH' {
+    let riskScore = 0;
+    if ((analysis.impact_categories.security_sensitive?.length ?? 0) > 0) riskScore += 30;
+    if ((analysis.impact_categories.breaking_changes?.length ?? 0) > 0) riskScore += 25;
+    if ((analysis.impact_categories.database_changes?.length ?? 0) > 0) riskScore += 20;
+    if ((analysis.impact_categories.api_changes?.length ?? 0) > 0) riskScore += 15;
+    if (riskScore >= 50) return 'HIGH';
+    if (riskScore >= 25) return 'MEDIUM';
+    return 'LOW';
+  }
+
+  private generateImpactRecommendations(analysis: DiffImpactResult): string[] {
+    const recommendations: string[] = [];
+    if ((analysis.impact_categories.security_sensitive?.length ?? 0) > 0)
+      recommendations.push('Conduct thorough security review and testing');
+    if (analysis.overall_risk === 'HIGH')
+      recommendations.push('Consider staged deployment and increased monitoring');
+    return recommendations;
+  }
+
+  private scanFileForSecurity(file: PRFile): SecurityResult['vulnerabilities'] {
+    const vulnerabilities: SecurityResult['vulnerabilities'] = [];
+    if (!file.patch) return vulnerabilities;
+    const addedLines = file.patch.split('\n').filter((l) => l.startsWith('+'));
+    const codeText = addedLines.join('\n');
+    for (const [category, patterns] of Object.entries(SECURITY_PATTERNS)) {
+      for (const pattern of patterns) {
+        if (pattern.test(codeText)) {
+          vulnerabilities.push({
+            type: category,
+            file: file.filename,
+            severity: this.getSecuritySeverity(category),
+            description: this.getSecurityDescription(category),
+          });
+        }
+      }
+    }
+    return vulnerabilities;
+  }
+
+  private getSecuritySeverity(category: string): Severity {
+    const severityMap: Record<string, Severity> = {
+      sql_injection: 'critical',
+      xss: 'high',
+      hardcoded_secrets: 'high',
+      insecure_random: 'medium',
+      eval_usage: 'high',
+    };
+    return severityMap[category] ?? 'medium';
+  }
+
+  private getSecurityDescription(category: string): string {
+    const descriptions: Record<string, string> = {
+      sql_injection: 'Potential SQL injection vulnerability detected',
+      xss: 'Potential XSS vulnerability detected',
+      hardcoded_secrets: 'Hardcoded secrets or credentials found',
+      insecure_random: 'Insecure random number generation',
+      eval_usage: 'Dangerous eval() or similar function usage',
+    };
+    return descriptions[category] ?? 'Security issue detected';
+  }
+
+  private calculateSecurityScore(analysis: SecurityResult): number {
+    let score = 100;
+    for (const vuln of analysis.vulnerabilities) {
+      switch (vuln.severity) {
+        case 'critical':
+          score -= 25;
+          break;
+        case 'high':
+          score -= 15;
+          break;
+        case 'medium':
+          score -= 5;
+          break;
+        case 'low':
+          score -= 2;
+          break;
+      }
+    }
+    return Math.max(0, score);
+  }
+
+  private analyzeFilePatterns(file: PRFile): {
+    good_patterns: Array<{ name: string; file: string; description: string }>;
+    anti_patterns: Array<{ name: string; file: string; description: string }>;
+  } {
+    const result = {
+      good_patterns: [] as Array<{ name: string; file: string; description: string }>,
+      anti_patterns: [] as Array<{ name: string; file: string; description: string }>,
+    };
+    if (!file.patch) return result;
+    const codeText = file.patch;
+    for (const antiPattern of ANTI_PATTERNS) {
+      if (antiPattern.pattern.test(codeText)) {
+        result.anti_patterns.push({ name: antiPattern.name, file: file.filename, description: antiPattern.description });
+      }
+    }
+    for (const goodPattern of GOOD_PATTERNS) {
+      if (goodPattern.pattern.test(codeText)) {
+        result.good_patterns.push({ name: goodPattern.name, file: file.filename, description: goodPattern.description });
+      }
+    }
+    return result;
+  }
+
+  private generatePatternRecommendations(analysis: CodePatternsResult): string[] {
+    const recommendations: string[] = [];
+    if (analysis.patterns_found.anti_patterns.length > 0)
+      recommendations.push('Address identified anti-patterns to improve code maintainability');
+    if (analysis.patterns_found.good_patterns.length > 0)
+      recommendations.push('Continue using the identified good design patterns');
+    return recommendations;
+  }
+
+  private isDependencyFile(filename: string): boolean {
+    return DEPENDENCY_PACKAGE_FILES.includes(filename) || DEPENDENCY_LOCK_FILES.includes(filename);
+  }
+
+  private generateDependencyRecommendations(dependencyFileCount: number): string[] {
+    const recommendations: string[] = [];
+    if (dependencyFileCount > 0)
+      recommendations.push('Review new dependencies for security and licensing compliance');
+    return recommendations;
+  }
+
+  private isTestFile(filename: string): boolean {
+    return (
+      filename.includes('test') ||
+      filename.includes('spec') ||
+      filename.includes('__tests__') ||
+      filename.endsWith('.test.js') ||
+      filename.endsWith('.spec.js')
+    );
+  }
+
+  private isProductionFile(filename: string): boolean {
+    return (
+      !this.isTestFile(filename) &&
+      !filename.includes('config') &&
+      !filename.includes('README') &&
+      !filename.includes('documentation')
+    );
+  }
+
+  private estimateTestCoverage(testFiles: PRFile[], productionFiles: PRFile[]): number {
+    if (productionFiles.length === 0) return 100;
+    const ratio = testFiles.length / productionFiles.length;
+    return Math.min(100, Math.round(ratio * 80));
+  }
+
+  private identifyMissingTests(
+    productionFiles: PRFile[],
+    testFiles: PRFile[],
+  ): Array<{ filename: string; suggested_test_file: string }> {
+    const missingTests: Array<{ filename: string; suggested_test_file: string }> = [];
+    for (const prodFile of productionFiles) {
+      const baseName = prodFile.filename.replace(/\.[^.]+$/, '');
+      const hasTest = testFiles.some((testFile) => testFile.filename.includes(baseName));
+      if (!hasTest) {
+        missingTests.push({ filename: prodFile.filename, suggested_test_file: `${baseName}.test.js` });
+      }
+    }
+    return missingTests;
+  }
+
+  private analyzeTestQuality(testFiles: PRFile[]): TestCoverageResult['test_quality'] {
+    let unitTests = 0;
+    let integrationTests = 0;
+    let edgeCases = 0;
+    for (const testFile of testFiles) {
+      if (!testFile.patch) continue;
+      const content = testFile.patch;
+      unitTests += (content.match(/describe|it|test\(/g) ?? []).length;
+      integrationTests += (content.match(/request|supertest|integration/gi) ?? []).length;
+      edgeCases += (content.match(/edge|boundary|null|undefined|empty/gi) ?? []).length;
+    }
+    return { unit_tests: unitTests, integration_tests: integrationTests, edge_cases: edgeCases };
+  }
+
+  private generateTestRecommendations(
+    coverageEstimate: number,
+    missingTests: Array<{ filename: string }>,
+    testQuality: TestCoverageResult['test_quality'],
+  ): string[] {
+    const recommendations: string[] = [];
+    if (coverageEstimate < 70) recommendations.push('Consider adding more test coverage for the changed code');
+    if (missingTests.length > 0)
+      recommendations.push(`Add tests for: ${missingTests.map((t) => t.filename).join(', ')}`);
+    if (testQuality.edge_cases === 0) recommendations.push('Consider adding edge case testing');
+    return recommendations;
+  }
+}

--- a/refactor/src/services/analysis.ts
+++ b/refactor/src/services/analysis.ts
@@ -493,6 +493,7 @@ export class AnalysisService {
     const codeText = addedLines.join('\n');
     for (const [category, patterns] of Object.entries(SECURITY_PATTERNS)) {
       for (const pattern of patterns) {
+        pattern.lastIndex = 0;
         if (pattern.test(codeText)) {
           vulnerabilities.push({
             type: category,

--- a/refactor/src/services/analysis.ts
+++ b/refactor/src/services/analysis.ts
@@ -561,11 +561,13 @@ export class AnalysisService {
     if (!file.patch) return result;
     const codeText = file.patch;
     for (const antiPattern of ANTI_PATTERNS) {
+      antiPattern.pattern.lastIndex = 0;
       if (antiPattern.pattern.test(codeText)) {
         result.anti_patterns.push({ name: antiPattern.name, file: file.filename, description: antiPattern.description });
       }
     }
     for (const goodPattern of GOOD_PATTERNS) {
+      goodPattern.pattern.lastIndex = 0;
       if (goodPattern.pattern.test(codeText)) {
         result.good_patterns.push({ name: goodPattern.name, file: file.filename, description: goodPattern.description });
       }

--- a/refactor/src/services/analysis.ts
+++ b/refactor/src/services/analysis.ts
@@ -585,7 +585,8 @@ export class AnalysisService {
   }
 
   private isDependencyFile(filename: string): boolean {
-    return DEPENDENCY_PACKAGE_FILES.includes(filename) || DEPENDENCY_LOCK_FILES.includes(filename);
+    const basename = filename.split('/').pop() ?? filename;
+    return DEPENDENCY_PACKAGE_FILES.includes(basename) || DEPENDENCY_LOCK_FILES.includes(basename);
   }
 
   private generateDependencyRecommendations(dependencyFileCount: number): string[] {

--- a/refactor/src/services/analysis.ts
+++ b/refactor/src/services/analysis.ts
@@ -178,7 +178,7 @@ export class AnalysisService {
     if (!file.patch) return analysis;
 
     const lines = file.patch.split('\n');
-    const addedLines = lines.filter((l) => l.startsWith('+')).slice(1);
+    const addedLines = lines.filter((l) => l.startsWith('+'));
 
     analysis.metrics.lines_of_code = addedLines.length;
     analysis.metrics.cyclomatic_complexity = this.calculateComplexity(addedLines, language);

--- a/refactor/src/services/config.test.ts
+++ b/refactor/src/services/config.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { ConfigService } from './config.js';
+
+describe('ConfigService', () => {
+  const originalEnv = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  function setEnv(vars: Record<string, string | undefined>) {
+    for (const [k, v] of Object.entries(vars)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+
+  describe('construction / validation', () => {
+    it('throws when a required variable is missing', () => {
+      setEnv({
+        GITHUB_APP_ID: undefined,
+        GITHUB_APP_PRIVATE_KEY: undefined,
+        MCP_API_SECRET: undefined,
+      });
+      expect(() => new ConfigService()).toThrow(/GITHUB_APP_ID/);
+    });
+
+    it('constructs when all required vars are present', () => {
+      setEnv({
+        GITHUB_APP_ID: '123456',
+        GITHUB_APP_PRIVATE_KEY: '-----BEGIN PRIVATE KEY-----\nkey\n-----END PRIVATE KEY-----',
+        MCP_API_SECRET: 'super-secret',
+        PORT: '4321',
+        MAX_PATCH_SIZE: '999',
+        MAX_FILES_TO_REVIEW: '7',
+        REQUEST_TIMEOUT: '5000',
+      });
+      const cfg = new ConfigService();
+      expect(cfg.githubAppId).toBe('123456');
+      expect(cfg.port).toBe(4321);
+      expect(cfg.maxPatchSize).toBe(999);
+      expect(cfg.maxFilesToReview).toBe(7);
+      expect(cfg.requestTimeout).toBe(5000);
+    });
+
+    it('uses defaults when optional vars are absent', () => {
+      setEnv({
+        GITHUB_APP_ID: '1',
+        GITHUB_APP_PRIVATE_KEY: 'k',
+        MCP_API_SECRET: 's',
+        PORT: undefined,
+        MAX_PATCH_SIZE: undefined,
+        MAX_FILES_TO_REVIEW: undefined,
+        REQUEST_TIMEOUT: undefined,
+      });
+      const cfg = new ConfigService();
+      expect(cfg.port).toBe(3000);
+      expect(cfg.maxPatchSize).toBeGreaterThan(0);
+      expect(cfg.maxFilesToReview).toBeGreaterThan(0);
+      expect(cfg.requestTimeout).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isRepoAllowed', () => {
+    it('allows all repos when allowlist is empty', () => {
+      setEnv({
+        GITHUB_APP_ID: '1',
+        GITHUB_APP_PRIVATE_KEY: 'k',
+        MCP_API_SECRET: 's',
+        REPO_ALLOWLIST: undefined,
+      });
+      const cfg = new ConfigService();
+      expect(cfg.isRepoAllowed('any', 'repo')).toBe(true);
+    });
+
+    it('only allows repos present in the allowlist', () => {
+      setEnv({
+        GITHUB_APP_ID: '1',
+        GITHUB_APP_PRIVATE_KEY: 'k',
+        MCP_API_SECRET: 's',
+        REPO_ALLOWLIST: 'octocat/Hello-World, foo/bar ',
+      });
+      const cfg = new ConfigService();
+      expect(cfg.isRepoAllowed('octocat', 'Hello-World')).toBe(true);
+      expect(cfg.isRepoAllowed('foo', 'bar')).toBe(true);
+      expect(cfg.isRepoAllowed('foo', 'baz')).toBe(false);
+      expect(cfg.isRepoAllowed('other', 'repo')).toBe(false);
+    });
+  });
+
+  describe('toDebugObject masks secrets', () => {
+    it('never reveals private key or api secret', () => {
+      setEnv({
+        GITHUB_APP_ID: '111',
+        GITHUB_APP_PRIVATE_KEY: 'TOPSECRET',
+        MCP_API_SECRET: 'DONOTLEAK',
+        REPO_ALLOWLIST: 'a/b',
+      });
+      const cfg = new ConfigService();
+      const dump = JSON.stringify(cfg.toDebugObject());
+      expect(dump).not.toContain('TOPSECRET');
+      expect(dump).not.toContain('DONOTLEAK');
+      expect(dump).toContain('111');
+    });
+  });
+});

--- a/refactor/src/services/config.ts
+++ b/refactor/src/services/config.ts
@@ -1,0 +1,115 @@
+/**
+ * Config service: parses environment variables, validates required ones,
+ * and masks secrets in debug output (mirroring the legacy `toObject()` masking).
+ */
+import type { IConfigService } from '../types/index.js';
+
+/** Names of env vars that must never be logged in full. */
+const SECRET_KEYS = new Set(['GITHUB_APP_PRIVATE_KEY', 'MCP_API_SECRET']);
+
+/** Default values for optional numeric knobs. */
+const DEFAULTS = {
+  PORT: 3000,
+  MAX_PATCH_SIZE: 2000,
+  MAX_FILES_TO_REVIEW: 50,
+  REQUEST_TIMEOUT: 30000,
+} as const;
+
+function parseIntOrDefault(raw: string | undefined, def: number): number {
+  if (raw === undefined || raw === '') return def;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : def;
+}
+
+function parseAllowlist(raw: string | undefined): string[] {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => s.toLowerCase());
+}
+
+/**
+ * Parses environment configuration for the MCP review server.
+ *
+ * Throws on the first missing required variable so callers fail fast.
+ */
+export class ConfigService implements IConfigService {
+  readonly githubAppId: string;
+  readonly githubAppPrivateKey: string;
+  readonly mcpApiSecret: string;
+  readonly port: number;
+  readonly maxPatchSize: number;
+  readonly maxFilesToReview: number;
+  readonly requestTimeout: number;
+  /** Lowercased `owner/repo` entries; empty = allow all installed repos. */
+  private readonly allowlist: string[];
+
+  constructor() {
+    const gitHubAppId = process.env.GITHUB_APP_ID;
+    const gitHubAppPrivateKey = process.env.GITHUB_APP_PRIVATE_KEY;
+    const mcpApiSecret = process.env.MCP_API_SECRET;
+
+    const missing: string[] = [];
+    if (!gitHubAppId) missing.push('GITHUB_APP_ID');
+    if (!gitHubAppPrivateKey) missing.push('GITHUB_APP_PRIVATE_KEY');
+    if (!mcpApiSecret) missing.push('MCP_API_SECRET');
+    if (missing.length > 0) {
+      throw new Error(`Missing required configuration: ${missing.join(', ')}`);
+    }
+
+    this.githubAppId = gitHubAppId as string;
+    this.githubAppPrivateKey = gitHubAppPrivateKey as string;
+    this.mcpApiSecret = mcpApiSecret as string;
+    this.port = parseIntOrDefault(process.env.PORT, DEFAULTS.PORT);
+    this.maxPatchSize = parseIntOrDefault(
+      process.env.MAX_PATCH_SIZE,
+      DEFAULTS.MAX_PATCH_SIZE,
+    );
+    this.maxFilesToReview = parseIntOrDefault(
+      process.env.MAX_FILES_TO_REVIEW,
+      DEFAULTS.MAX_FILES_TO_REVIEW,
+    );
+    this.requestTimeout = parseIntOrDefault(
+      process.env.REQUEST_TIMEOUT,
+      DEFAULTS.REQUEST_TIMEOUT,
+    );
+    this.allowlist = parseAllowlist(process.env.REPO_ALLOWLIST);
+  }
+
+  /**
+   * Returns true when the repo is permitted.
+   *
+   * An empty allowlist permits all repos where the App is installed; this is
+   * enforced elsewhere. With a non-empty allowlist only listed `owner/repo`
+   * pairs (case-insensitive) pass.
+   */
+  isRepoAllowed(owner: string, repo: string): boolean {
+    if (this.allowlist.length === 0) return true;
+    return this.allowlist.includes(`${owner}/${repo}`.toLowerCase());
+  }
+
+  /** Safe-to-log config snapshot with secrets masked. */
+  toDebugObject(): Record<string, string | number | boolean | undefined> {
+    const dump: Record<string, string | number | boolean | undefined> = {
+      GITHUB_APP_ID: this.githubAppId,
+      GITHUB_APP_PRIVATE_KEY:
+        this.githubAppPrivateKey ? '[SET]' : '[NOT SET]',
+      MCP_API_SECRET: this.mcpApiSecret ? '[SET]' : '[NOT SET]',
+      REPO_ALLOWLIST:
+        this.allowlist.length > 0 ? this.allowlist.join(', ') : '(all)',
+      PORT: this.port,
+      MAX_PATCH_SIZE: this.maxPatchSize,
+      MAX_FILES_TO_REVIEW: this.maxFilesToReview,
+      REQUEST_TIMEOUT: this.requestTimeout,
+    };
+    // Belt and braces: scrub any secret value that slipped in.
+    for (const key of Object.keys(dump)) {
+      if (SECRET_KEYS.has(key) && typeof dump[key] === 'string') {
+        dump[key] = '[SET]';
+      }
+    }
+    return dump;
+  }
+}

--- a/refactor/src/services/github.test.ts
+++ b/refactor/src/services/github.test.ts
@@ -14,6 +14,10 @@ function makeMockOctokit(overrides: Partial<{
   languages: Record<string, number>;
   readme: string | null;
 }> = {}) {
+  const paginate = vi.fn(async (method: (params: Record<string, unknown>) => Promise<{ data: unknown[] }>, params: Record<string, unknown>) => {
+    const res = await method(params);
+    return res.data;
+  });
   const pulls = {
     get: vi.fn(async () => ({ data: overrides.pr ?? { id: 1, number: 42, title: 'T', body: null, state: 'open', user: { login: 'octocat' }, created_at: '2024-01-01', updated_at: '2024-01-02', base: { ref: 'main' }, head: { ref: 'feat' }, mergeable: true, additions: 5, deletions: 1, changed_files: 2 } })),
     listFiles: vi.fn(async () => ({ data: overrides.files ?? [{ filename: 'a.js', status: 'modified', additions: 2, deletions: 1, changes: 3, patch: '@@ -1,2 +1,3 @@' }] })),
@@ -43,7 +47,7 @@ function makeMockOctokit(overrides: Partial<{
       return { data: { content: Buffer.from(overrides.readme ?? '# Readme').toString('base64') } };
     }),
   };
-  return { rest: { pulls, repos } };
+  return { paginate, rest: { pulls, repos } };
 }
 
 const PR_URL = 'https://github.com/octocat/Hello-World/pull/42';
@@ -73,6 +77,10 @@ describe('GitHubService.getPRDetails', () => {
     expect(details.commits[0].sha).toBe('s1');
     expect(details.existing_reviews[0].user).toBe('r');
     expect(details.repository.full_name).toBe('octocat/Hello-World');
+    expect(mock.paginate).toHaveBeenCalledTimes(3);
+    expect(mock.paginate).toHaveBeenCalledWith(mock.rest.pulls.listFiles, { owner: 'octocat', repo: 'Hello-World', pull_number: 42, per_page: 100 });
+    expect(mock.paginate).toHaveBeenCalledWith(mock.rest.pulls.listCommits, { owner: 'octocat', repo: 'Hello-World', pull_number: 42, per_page: 100 });
+    expect(mock.paginate).toHaveBeenCalledWith(mock.rest.pulls.listReviews, { owner: 'octocat', repo: 'Hello-World', pull_number: 42, per_page: 100 });
   });
 });
 

--- a/refactor/src/services/github.test.ts
+++ b/refactor/src/services/github.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi } from 'vitest';
+import { GitHubService } from './github.js';
+
+/** Builds a mock Octokit with controllable responses for the GitHubService surface. */
+function makeMockOctokit(overrides: Partial<{
+  pr: Record<string, unknown>;
+  files: unknown[];
+  commits: unknown[];
+  reviews: unknown[];
+  contentFile: { type: string; content: string; encoding: string };
+  contentFns: { (params: unknown): Promise<unknown> };
+  compare: Record<string, unknown>;
+  reviewCreated: Record<string, unknown>;
+  languages: Record<string, number>;
+  readme: string | null;
+}> = {}) {
+  const pulls = {
+    get: vi.fn(async () => ({ data: overrides.pr ?? { id: 1, number: 42, title: 'T', body: null, state: 'open', user: { login: 'octocat' }, created_at: '2024-01-01', updated_at: '2024-01-02', base: { ref: 'main' }, head: { ref: 'feat' }, mergeable: true, additions: 5, deletions: 1, changed_files: 2 } })),
+    listFiles: vi.fn(async () => ({ data: overrides.files ?? [{ filename: 'a.js', status: 'modified', additions: 2, deletions: 1, changes: 3, patch: '@@ -1,2 +1,3 @@' }] })),
+    listCommits: vi.fn(async () => ({ data: overrides.commits ?? [{ sha: 'abc', commit: { message: 'm', author: { name: 'A', date: '2024' } } }] })),
+    listReviews: vi.fn(async () => ({ data: overrides.reviews ?? [] })),
+    createReview: vi.fn(async () => ({ data: overrides.reviewCreated ?? { id: 999, html_url: 'https://github.com/o/r/pull/42#review-999' } })),
+  };
+  const repos = {
+    getContent: overrides.contentFns
+      ? (overrides.contentFns as never)
+      : vi.fn(async (params: { path?: string }) => {
+          if (params.path === 'missing.txt') {
+            const err = new Error('NF');
+            (err as Error & { status: number }).status = 404;
+            throw err;
+          }
+          return { data: overrides.contentFile ?? { type: 'file', content: Buffer.from('hello').toString('base64'), encoding: 'base64' } };
+        }),
+    compareCommits: vi.fn(async () => ({ data: overrides.compare ?? { total_commits: 2, files: [{ filename: 'd.js', status: 'added', additions: 1, deletions: 0, changes: 1, patch: '@@ +1 @@', blob_url: 'u' }] } })),
+    listLanguages: vi.fn(async () => ({ data: overrides.languages ?? { JavaScript: 100, TypeScript: 50 } })),
+    getReadme: vi.fn(async () => {
+      if (overrides.readme === null) {
+        const err = new Error('NF');
+        (err as Error & { status: number }).status = 404;
+        throw err;
+      }
+      return { data: { content: Buffer.from(overrides.readme ?? '# Readme').toString('base64') } };
+    }),
+  };
+  return { rest: { pulls, repos } };
+}
+
+const PR_URL = 'https://github.com/octocat/Hello-World/pull/42';
+
+describe('GitHubService.parsePRURL', () => {
+  it('parses owner, repo, and pull number', () => {
+    const svc = new GitHubService(makeMockOctokit() as never);
+    expect(svc.parsePRURL(PR_URL)).toEqual({ owner: 'octocat', repo: 'Hello-World', pull_number: 42 });
+  });
+  it('throws on an invalid URL', () => {
+    const svc = new GitHubService(makeMockOctokit() as never);
+    expect(() => svc.parsePRURL('https://example.com')).toThrow(/invalid/i);
+  });
+});
+
+describe('GitHubService.getPRDetails', () => {
+  it('assembles PR + files + commits + existing reviews', async () => {
+    const mock = makeMockOctokit({
+      files: [{ filename: 'a.js', status: 'modified', additions: 2, deletions: 1, changes: 3, patch: 'P', blob_url: 'bu' }],
+      commits: [{ sha: 's1', commit: { message: 'fix', author: { name: 'A', date: '2024' } } }],
+      reviews: [{ id: 5, user: { login: 'r' }, state: 'COMMENT', body: 'hi', submitted_at: '2024' }],
+    });
+    const svc = new GitHubService(mock as never);
+    const details = await svc.getPRDetails(PR_URL);
+    expect(details.pr.number).toBe(42);
+    expect(details.files).toHaveLength(1);
+    expect(details.commits[0].sha).toBe('s1');
+    expect(details.existing_reviews[0].user).toBe('r');
+    expect(details.repository.full_name).toBe('octocat/Hello-World');
+  });
+});
+
+describe('GitHubService.getPRFiles', () => {
+  it('returns files with patches when include_patch is true', async () => {
+    const mock = makeMockOctokit({ files: [{ filename: 'a.js', status: 'modified', additions: 1, deletions: 1, changes: 2, patch: '@@ patch @@' }] });
+    const svc = new GitHubService(mock as never);
+    const files = await svc.getPRFiles(PR_URL, true);
+    expect(files[0].patch).toBe('@@ patch @@');
+  });
+  it('omits patches when include_patch is false', async () => {
+    const mock = makeMockOctokit({ files: [{ filename: 'a.js', status: 'modified', additions: 1, deletions: 1, changes: 2, patch: '@@ patch @@' }] });
+    const svc = new GitHubService(mock as never);
+    const files = await svc.getPRFiles(PR_URL, false);
+    expect(files[0].patch).toBeUndefined();
+  });
+});
+
+describe('GitHubService.getPRCommits', () => {
+  it('returns commits for the PR', async () => {
+    const mock = makeMockOctokit({ commits: [{ sha: 's1', commit: { message: 'm', author: { name: 'A', date: '2024' } } }] });
+    const svc = new GitHubService(mock as never);
+    const commits = await svc.getPRCommits(PR_URL);
+    expect(commits[0].sha).toBe('s1');
+    expect(commits).toHaveLength(1);
+  });
+});
+
+describe('GitHubService.getFileContent', () => {
+  it('decodes base64 file content', async () => {
+    const mock = makeMockOctokit();
+    const svc = new GitHubService(mock as never);
+    const content = await svc.getFileContent('o', 'r', 'path/to/file.txt', 'main');
+    expect(content).toBe('hello');
+    expect(mock.rest.repos.getContent).toHaveBeenCalledWith({ owner: 'o', repo: 'r', path: 'path/to/file.txt', ref: 'main' });
+  });
+  it('returns null when the file does not exist', async () => {
+    const mock = makeMockOctokit();
+    const svc = new GitHubService(mock as never);
+    const content = await svc.getFileContent('o', 'r', 'missing.txt');
+    expect(content).toBeNull();
+  });
+});
+
+describe('GitHubService.getDiffRange', () => {
+  it('uses the compare API and returns files + counts', async () => {
+    const mock = makeMockOctokit({
+      compare: { total_commits: 3, files: [{ filename: 'd.js', status: 'added', additions: 1, deletions: 0, changes: 1, patch: '@@ p @@', blob_url: 'bu' }] },
+    });
+    const svc = new GitHubService(mock as never);
+    const diff = await svc.getDiffRange('o', 'r', 'baseSHA', 'headSHA');
+    expect(mock.rest.repos.compareCommits).toHaveBeenCalledWith({ owner: 'o', repo: 'r', base: 'baseSHA', head: 'headSHA' });
+    expect(diff.base_sha).toBe('baseSHA');
+    expect(diff.head_sha).toBe('headSHA');
+    expect(diff.total_commits).toBe(3);
+    expect(diff.files).toHaveLength(1);
+    expect(diff.files[0].filename).toBe('d.js');
+  });
+});
+
+describe('GitHubService.createReview', () => {
+  it('maps inline comments and returns success/id/url', async () => {
+    const mock = makeMockOctokit();
+    const svc = new GitHubService(mock as never);
+    const result = await svc.createReview('o', 'r', 42, {
+      body: 'Review body',
+      event: 'COMMENT',
+      comments: [
+        { path: 'a.js', line: 10, body: 'c1', side: 'RIGHT', start_line: 8 },
+      ],
+    });
+    expect(result.success).toBe(true);
+    expect(result.review_id).toBe(999);
+    expect(result.review_url).toContain('review-999');
+    expect(mock.rest.pulls.createReview).toHaveBeenCalledWith({
+      owner: 'o',
+      repo: 'r',
+      pull_number: 42,
+      body: 'Review body',
+      event: 'COMMENT',
+      comments: [{ path: 'a.js', line: 10, body: 'c1', side: 'RIGHT', start_line: 8 }],
+    });
+  });
+  it('defaults event to COMMENT and comments to []', async () => {
+    const mock = makeMockOctokit();
+    const svc = new GitHubService(mock as never);
+    await svc.createReview('o', 'r', 7, { body: 'b' });
+    expect(mock.rest.pulls.createReview).toHaveBeenCalledWith({
+      owner: 'o', repo: 'r', pull_number: 7, body: 'b', event: 'COMMENT', comments: [],
+    });
+  });
+});
+
+describe('GitHubService.getRepoInfo', () => {
+  it('returns languages, primary language, and readme presence', async () => {
+    const mock = makeMockOctokit({ languages: { TypeScript: 90, JavaScript: 10 }, readme: '# Readme' });
+    const svc = new GitHubService(mock as never);
+    const info = await svc.getRepoInfo('o', 'r');
+    expect(info.primary_language).toBe('TypeScript');
+    expect(info.has_readme).toBe(true);
+    expect(info.readme_content).toBe('# Readme');
+    expect(info.full_name).toBe('o/r');
+  });
+  it('handles missing readme', async () => {
+    const mock = makeMockOctokit({ readme: null });
+    const svc = new GitHubService(mock as never);
+    const info = await svc.getRepoInfo('o', 'r');
+    expect(info.has_readme).toBe(false);
+    expect(info.readme_content).toBeNull();
+  });
+});

--- a/refactor/src/services/github.ts
+++ b/refactor/src/services/github.ts
@@ -1,0 +1,1 @@
+// placeholder

--- a/refactor/src/services/github.ts
+++ b/refactor/src/services/github.ts
@@ -25,6 +25,10 @@ import type {
  * transport specifics and easily mockable in tests.
  */
 interface OctokitSlice {
+  paginate?<T, P extends object>(
+    method: (params: P) => Promise<{ data: T[] }>,
+    params: P,
+  ): Promise<T[]>;
   rest: {
     pulls: {
       get(params: { owner: string; repo: string; pull_number: number }): Promise<{
@@ -148,8 +152,23 @@ interface DiffFileRaw {
 const PR_URL_RE =
   /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/i;
 
-/** Default page size for listing files and commits; capped at GitHub's max. */
+/** Default page size for paginated PR listings; capped at GitHub's max. */
 const LIST_PER_PAGE = 100;
+
+async function paginatePRList<T>(
+  octokit: OctokitSlice,
+  method: (params: never) => Promise<{ data: T[] }>,
+  params: Record<string, unknown>,
+): Promise<T[]> {
+  const requestParams = { ...params, per_page: LIST_PER_PAGE };
+  const request = method as (params: Record<string, unknown>) => Promise<{ data: T[] }>;
+  if (octokit.paginate) {
+    return octokit.paginate(request, requestParams);
+  }
+
+  const firstPage = await request(requestParams);
+  return firstPage.data;
+}
 
 export class GitHubService implements IGitHubService {
   constructor(private readonly octokit: OctokitSlice) {}
@@ -172,23 +191,21 @@ export class GitHubService implements IGitHubService {
 
     const prRes = await api.pulls.get({ owner, repo, pull_number });
     const pr = prRes.data;
-    const filesRes = await api.pulls.listFiles({
-      owner,
-      repo,
-      pull_number,
-      per_page: LIST_PER_PAGE,
-    });
-    const commitsRes = await api.pulls.listCommits({
-      owner,
-      repo,
-      pull_number,
-      per_page: LIST_PER_PAGE,
-    });
-    const reviewsRes = await api.pulls.listReviews({
-      owner,
-      repo,
-      pull_number,
-    });
+    const files = await paginatePRList<PRFileRaw>(
+      this.octokit,
+      api.pulls.listFiles,
+      { owner, repo, pull_number },
+    );
+    const commits = await paginatePRList<PRCommitRaw>(
+      this.octokit,
+      api.pulls.listCommits,
+      { owner, repo, pull_number },
+    );
+    const reviews = await paginatePRList<ReviewRaw>(
+      this.octokit,
+      api.pulls.listReviews,
+      { owner, repo, pull_number },
+    );
 
     return {
       pr: {
@@ -207,9 +224,9 @@ export class GitHubService implements IGitHubService {
         deletions: pr.deletions ?? 0,
         changed_files: pr.changed_files ?? 0,
       },
-      files: filesRes.data.map((f) => toPRFile(f)),
-      commits: commitsRes.data.map(toPRCommit),
-      existing_reviews: reviewsRes.data.map(toExistingReview),
+      files: files.map((f) => toPRFile(f)),
+      commits: commits.map(toPRCommit),
+      existing_reviews: reviews.map(toExistingReview),
       repository: {
         owner,
         repo,
@@ -220,24 +237,22 @@ export class GitHubService implements IGitHubService {
 
   async getPRFiles(pr_url: string, include_patch = true): Promise<PRFile[]> {
     const { owner, repo, pull_number } = this.parsePRURL(pr_url);
-    const res = await this.octokit.rest.pulls.listFiles({
-      owner,
-      repo,
-      pull_number,
-      per_page: LIST_PER_PAGE,
-    });
-    return res.data.map((f) => toPRFile(f, include_patch));
+    const files = await paginatePRList<PRFileRaw>(
+      this.octokit,
+      this.octokit.rest.pulls.listFiles,
+      { owner, repo, pull_number },
+    );
+    return files.map((f) => toPRFile(f, include_patch));
   }
 
   async getPRCommits(pr_url: string): Promise<PRCommit[]> {
     const { owner, repo, pull_number } = this.parsePRURL(pr_url);
-    const res = await this.octokit.rest.pulls.listCommits({
-      owner,
-      repo,
-      pull_number,
-      per_page: LIST_PER_PAGE,
-    });
-    return res.data.map(toPRCommit);
+    const commits = await paginatePRList<PRCommitRaw>(
+      this.octokit,
+      this.octokit.rest.pulls.listCommits,
+      { owner, repo, pull_number },
+    );
+    return commits.map(toPRCommit);
   }
 
   async getFileContent(

--- a/refactor/src/services/github.ts
+++ b/refactor/src/services/github.ts
@@ -1,1 +1,401 @@
-// placeholder
+/**
+ * GitHubService — typed Octokit wrapper implementing `IGitHubService`.
+ *
+ * All methods accept either a pre-resolved PR URL or separate (owner, repo)
+ * arguments. The service never concerns itself with authentication; the
+ * caller passes an installation-scoped Octokit at construction time.
+ */
+
+import type {
+  IGitHubService,
+  PRRef,
+  PRDetails,
+  PRFile,
+  PRCommit,
+  ExistingReview,
+  DiffRange,
+  ReviewInput,
+  ReviewResult,
+  RepoInfo,
+} from '../types/index.js';
+
+/**
+ * Minimal structural type for the Octokit slice we use. We avoid importing
+ * the full `@octokit/rest` types here so the service stays independent of
+ * transport specifics and easily mockable in tests.
+ */
+interface OctokitSlice {
+  rest: {
+    pulls: {
+      get(params: { owner: string; repo: string; pull_number: number }): Promise<{
+        data: PRDataRaw;
+      }>;
+      listFiles(params: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+        per_page?: number;
+      }): Promise<{ data: PRFileRaw[] }>;
+      listCommits(params: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+        per_page?: number;
+      }): Promise<{ data: PRCommitRaw[] }>;
+      listReviews(params: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+      }): Promise<{ data: ReviewRaw[] }>;
+      createReview(params: {
+        owner: string;
+        repo: string;
+        pull_number: number;
+        body?: string;
+        event?: string;
+        comments?: unknown[];
+      }): Promise<{ data: { id: number; html_url?: string } }>;
+    };
+    repos: {
+      getContent(params: {
+        owner: string;
+        repo: string;
+        path: string;
+        ref?: string;
+      }): Promise<{
+        data:
+          | { type: string; content?: string; encoding?: string }
+          | Array<unknown>;
+      }>;
+      compareCommits(params: {
+        owner: string;
+        repo: string;
+        base: string;
+        head: string;
+      }): Promise<{
+        data: {
+          total_commits: number;
+          files?: DiffFileRaw[];
+        };
+      }>;
+      listLanguages(params: {
+        owner: string;
+        repo: string;
+      }): Promise<{ data: Record<string, number> }>;
+      getReadme(params: {
+        owner: string;
+        repo: string;
+      }): Promise<{
+        data: { content?: string; encoding?: string };
+      }>;
+    };
+  };
+}
+
+interface PRDataRaw {
+  id: number;
+  number: number;
+  title?: string;
+  body?: string | null;
+  state?: string;
+  user?: { login?: string } | null;
+  created_at?: string;
+  updated_at?: string;
+  base?: { ref?: string };
+  head?: { ref?: string };
+  mergeable?: boolean | null;
+  additions?: number;
+  deletions?: number;
+  changed_files?: number;
+}
+
+interface PRFileRaw {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+  blob_url?: string;
+}
+
+interface PRCommitRaw {
+  sha: string;
+  commit: {
+    message?: string;
+    author?: { name?: string; date?: string } | null;
+  };
+}
+
+interface ReviewRaw {
+  id: number;
+  user?: { login?: string } | null;
+  state?: string;
+  body?: string | null;
+  submitted_at?: string | null;
+}
+
+interface DiffFileRaw {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+  blob_url?: string;
+}
+
+const PR_URL_RE =
+  /^https?:\/\/github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)(?:[/?#].*)?$/i;
+
+/** Default page size for listing files and commits; capped at GitHub's max. */
+const LIST_PER_PAGE = 100;
+
+export class GitHubService implements IGitHubService {
+  constructor(private readonly octokit: OctokitSlice) {}
+
+  parsePRURL(url: string): PRRef {
+    const m = PR_URL_RE.exec(url.trim());
+    if (!m) {
+      throw new Error(`Invalid GitHub pull-request URL: ${url}`);
+    }
+    return {
+      owner: m[1],
+      repo: m[2],
+      pull_number: parseInt(m[3], 10),
+    };
+  }
+
+  async getPRDetails(pr_url: string): Promise<PRDetails> {
+    const { owner, repo, pull_number } = this.parsePRURL(pr_url);
+    const api = this.octokit.rest;
+
+    const prRes = await api.pulls.get({ owner, repo, pull_number });
+    const pr = prRes.data;
+    const filesRes = await api.pulls.listFiles({
+      owner,
+      repo,
+      pull_number,
+      per_page: LIST_PER_PAGE,
+    });
+    const commitsRes = await api.pulls.listCommits({
+      owner,
+      repo,
+      pull_number,
+      per_page: LIST_PER_PAGE,
+    });
+    const reviewsRes = await api.pulls.listReviews({
+      owner,
+      repo,
+      pull_number,
+    });
+
+    return {
+      pr: {
+        id: pr.id,
+        number: pr.number,
+        title: pr.title ?? '',
+        body: pr.body ?? null,
+        state: pr.state ?? 'open',
+        author: pr.user?.login ?? '',
+        created_at: pr.created_at ?? '',
+        updated_at: pr.updated_at ?? '',
+        base_branch: pr.base?.ref ?? '',
+        head_branch: pr.head?.ref ?? '',
+        mergeable: pr.mergeable ?? null,
+        additions: pr.additions ?? 0,
+        deletions: pr.deletions ?? 0,
+        changed_files: pr.changed_files ?? 0,
+      },
+      files: filesRes.data.map((f) => toPRFile(f)),
+      commits: commitsRes.data.map(toPRCommit),
+      existing_reviews: reviewsRes.data.map(toExistingReview),
+      repository: {
+        owner,
+        repo,
+        full_name: `${owner}/${repo}`,
+      },
+    };
+  }
+
+  async getPRFiles(pr_url: string, include_patch = true): Promise<PRFile[]> {
+    const { owner, repo, pull_number } = this.parsePRURL(pr_url);
+    const res = await this.octokit.rest.pulls.listFiles({
+      owner,
+      repo,
+      pull_number,
+      per_page: LIST_PER_PAGE,
+    });
+    return res.data.map((f) => toPRFile(f, include_patch));
+  }
+
+  async getPRCommits(pr_url: string): Promise<PRCommit[]> {
+    const { owner, repo, pull_number } = this.parsePRURL(pr_url);
+    const res = await this.octokit.rest.pulls.listCommits({
+      owner,
+      repo,
+      pull_number,
+      per_page: LIST_PER_PAGE,
+    });
+    return res.data.map(toPRCommit);
+  }
+
+  async getFileContent(
+    owner: string,
+    repo: string,
+    path: string,
+    ref?: string,
+  ): Promise<string | null> {
+    try {
+      const res = await this.octokit.rest.repos.getContent({
+        owner,
+        repo,
+        path,
+        ref,
+      });
+      if (Array.isArray(res.data)) return null;
+      const file = res.data;
+      if (file.type !== 'file' || file.content == null) return null;
+      // GitHub returns content base64-encoded; `encoding` may be absent.
+      const text =
+        file.encoding === undefined || file.encoding === 'base64'
+          ? Buffer.from(file.content, 'base64').toString('utf8')
+          : file.content;
+      return text;
+    } catch (err) {
+      const status = (err as Error & { status?: number }).status;
+      if (status === 404) return null;
+      throw err;
+    }
+  }
+
+  async getDiffRange(
+    owner: string,
+    repo: string,
+    base_sha: string,
+    head_sha: string,
+  ): Promise<DiffRange> {
+    const res = await this.octokit.rest.repos.compareCommits({
+      owner,
+      repo,
+      base: base_sha,
+      head: head_sha,
+    });
+    const files = res.data.files ?? [];
+    return {
+      base_sha,
+      head_sha,
+      total_commits: res.data.total_commits ?? 0,
+      total_files: files.length,
+      files: files.map((f) => ({
+        filename: f.filename,
+        status: f.status,
+        additions: f.additions,
+        deletions: f.deletions,
+        changes: f.changes,
+        patch: f.patch,
+        blob_url: f.blob_url,
+      })),
+    };
+  }
+
+  async createReview(
+    owner: string,
+    repo: string,
+    pull_number: number,
+    review: ReviewInput,
+  ): Promise<ReviewResult> {
+    const event = review.event ?? 'COMMENT';
+    const comments = (review.comments ?? []).map((c) => ({
+      path: c.path,
+      line: c.line,
+      body: c.body,
+      side: c.side,
+      start_line: c.start_line,
+    }));
+    const res = await this.octokit.rest.pulls.createReview({
+      owner,
+      repo,
+      pull_number,
+      body: review.body,
+      event,
+      comments,
+    });
+    return {
+      success: true,
+      review_id: res.data.id,
+      review_url: res.data.html_url ?? `https://github.com/${owner}/${repo}/pull/${pull_number}`,
+    };
+  }
+
+  async getRepoInfo(owner: string, repo: string): Promise<RepoInfo> {
+    const langsRes = await this.octokit.rest.repos.listLanguages({ owner, repo });
+    const languages = langsRes.data ?? {};
+    const primary_language = pickPrimaryLanguage(languages);
+
+    let readme_content: string | null = null;
+    let has_readme = false;
+    try {
+      const readmeRes = await this.octokit.rest.repos.getReadme({ owner, repo });
+      const raw = readmeRes.data.content ?? '';
+      // GitHub returns content base64-encoded; `encoding` may be absent.
+      readme_content =
+        readmeRes.data.encoding === undefined ||
+        readmeRes.data.encoding === 'base64'
+          ? Buffer.from(raw, 'base64').toString('utf8')
+          : raw;
+      has_readme = true;
+    } catch (err) {
+      const status = (err as Error & { status?: number }).status;
+      if (status !== 404) throw err;
+    }
+
+    return {
+      owner,
+      repo,
+      full_name: `${owner}/${repo}`,
+      languages,
+      primary_language,
+      has_readme,
+      readme_content,
+    };
+  }
+}
+
+function toPRFile(raw: PRFileRaw, include_patch = true): PRFile {
+  return {
+    filename: raw.filename,
+    status: raw.status,
+    additions: raw.additions,
+    deletions: raw.deletions,
+    changes: raw.changes,
+    ...(include_patch ? { patch: raw.patch } : {}),
+    blob_url: raw.blob_url,
+  };
+}
+
+function toPRCommit(raw: PRCommitRaw): PRCommit {
+  return {
+    sha: raw.sha,
+    message: raw.commit.message ?? '',
+    author: raw.commit.author?.name ?? '',
+    date: raw.commit.author?.date ?? '',
+  };
+}
+
+function toExistingReview(raw: ReviewRaw): ExistingReview {
+  return {
+    id: raw.id,
+    user: raw.user?.login ?? '',
+    state: raw.state ?? '',
+    body: raw.body ?? null,
+    submitted_at: raw.submitted_at ?? null,
+  };
+}
+
+function pickPrimaryLanguage(languages: Record<string, number>): string {
+  const entries = Object.entries(languages);
+  if (entries.length === 0) return 'Unknown';
+  entries.sort((a, b) => b[1] - a[1]);
+  return entries[0][0];
+}

--- a/refactor/src/services/github.ts
+++ b/refactor/src/services/github.ts
@@ -327,6 +327,7 @@ export class GitHubService implements IGitHubService {
       body: c.body,
       side: c.side,
       start_line: c.start_line,
+      start_side: c.start_side,
     }));
     const res = await this.octokit.rest.pulls.createReview({
       owner,

--- a/refactor/src/services/strategy.catalog.test.ts
+++ b/refactor/src/services/strategy.catalog.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import * as path from 'node:path';
+import * as url from 'node:url';
+import * as fs from 'node:fs/promises';
+import { StrategyService } from './strategy.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, '__fixtures__');
+
+describe('StrategyService catalog loading', () => {
+  const cleanDir = path.join(FIXTURES, 'strategies-clean');
+
+  beforeEach(async () => {
+    await fs.rm(cleanDir, { recursive: true, force: true });
+    await fs.mkdir(cleanDir, { recursive: true });
+    await fs.writeFile(
+      path.join(cleanDir, 'security.md'),
+      '---\nname: security\ndescription: security review\ntriggers:\n  - secrets\npriority: 2\n---\n\n# Security\nBody text.\n',
+    );
+    await fs.writeFile(
+      path.join(cleanDir, 'performance.md'),
+      '---\nname: performance\ndescription: perf review\n---\n\n# Perf\nBody.\n',
+    );
+  });
+
+  it('parses frontmatter metadata and body', () => {
+    const svc = new StrategyService({ catalogDir: cleanDir });
+    const catalog = svc.getCatalog();
+    expect(catalog.size).toBe(2);
+    const security = catalog.get('security');
+    expect(security?.description).toBe('security review');
+    expect(security?.triggers).toEqual(['secrets']);
+    expect(security?.priority).toBe(2);
+    expect(security?.body).toContain('# Security');
+    expect(security?.body).toContain('Body text.');
+    const perf = catalog.get('performance');
+    expect(perf?.name).toBe('performance');
+    expect(perf?.body).toMatch(/# Perf/);
+    expect(perf?.triggers).toBeUndefined();
+  });
+
+  it('errors on duplicate strategy names', () => {
+    expect(
+      () =>
+        new StrategyService({
+          catalogDir: path.join(FIXTURES, 'strategies'),
+        }),
+    ).toThrow(/duplicate/i);
+  });
+
+  it('errors on malformed frontmatter', () => {
+    expect(
+      () =>
+        new StrategyService({
+          catalogDir: path.join(FIXTURES, 'malformed-catalog'),
+        }),
+    ).toThrow();
+  });
+
+  it('errors on a strategy with an empty body', () => {
+    expect(
+      () =>
+        new StrategyService({
+          catalogDir: path.join(FIXTURES, 'empty-body-catalog'),
+        }),
+    ).toThrow(/body/i);
+  });
+
+  it('caches the catalog on first load (same map reference)', () => {
+    const svc = new StrategyService({ catalogDir: cleanDir });
+    const first = svc.getCatalog();
+    const second = svc.getCatalog();
+    expect(first).toBe(second);
+  });
+});

--- a/refactor/src/services/strategy.catalog.test.ts
+++ b/refactor/src/services/strategy.catalog.test.ts
@@ -8,7 +8,7 @@ const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 const FIXTURES = path.join(__dirname, '__fixtures__');
 
 describe('StrategyService catalog loading', () => {
-  const cleanDir = path.join(FIXTURES, 'strategies-clean');
+  const cleanDir = path.join(FIXTURES, 'strategies-catalog-clean');
 
   beforeEach(async () => {
     await fs.rm(cleanDir, { recursive: true, force: true });

--- a/refactor/src/services/strategy.resolve.test.ts
+++ b/refactor/src/services/strategy.resolve.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeAll } from 'vitest';
+import * as path from 'node:path';
+import * as url from 'node:url';
+import * as fs from 'node:fs/promises';
+import { StrategyService } from './strategy.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const FIXTURES = path.join(__dirname, '__fixtures__');
+const cleanDir = path.join(FIXTURES, 'strategies-resolve-clean');
+
+/** Minimal mock Octokit surface for `repos.getContent`. */
+function octokitWithContent(yaml: string | { notFound: true } | { malformed: true }) {
+  const get = vi.fn(async () => {
+    if (yaml && typeof yaml === 'object' && 'notFound' in yaml) {
+      const err = new Error('Not found');
+      (err as Error & { status: number }).status = 404;
+      throw err;
+    }
+    if (yaml && typeof yaml === 'object' && 'malformed' in yaml) {
+      return {
+        data: {
+          type: 'file',
+          encoding: 'base64',
+          content: Buffer.from('strategies: [[unclosed').toString('base64'),
+        },
+      };
+    }
+    return {
+      data: {
+        type: 'file',
+        encoding: 'base64',
+        content: Buffer.from(yaml as string).toString('base64'),
+      },
+    };
+  });
+  return {
+    rest: { repos: { getContent: get } },
+    get,
+  } as never;
+}
+
+const catalogYaml = (strategies: string[], def?: string) =>
+  def
+    ? `strategies:\n${strategies.map((s) => `  - ${s}`).join('\n')}\ndefault: ${def}\n`
+    : `strategies:\n${strategies.map((s) => `  - ${s}`).join('\n')}\n`;
+
+describe('StrategyService.resolveForRepo', () => {
+  let cleanStrategies: StrategyService;
+
+  beforeAll(async () => {
+    await fs.rm(cleanDir, { recursive: true, force: true });
+    await fs.mkdir(cleanDir, { recursive: true });
+    await fs.writeFile(
+      path.join(cleanDir, 'security.md'),
+      '---\nname: security\ndescription: security review\n---\n\n# Security\nbody.\n',
+    );
+    await fs.writeFile(
+      path.join(cleanDir, 'full-review.md'),
+      '---\nname: full-review\ndescription: full review\n---\n\n# Full\nbody.\n',
+    );
+    await fs.writeFile(
+      path.join(cleanDir, 'performance.md'),
+      '---\nname: performance\ndescription: perf review\n---\n\n# Perf\nbody.\n',
+    );
+    cleanStrategies = new StrategyService({ catalogDir: cleanDir });
+  });
+
+  it('intersects repo strategies with the catalog', async () => {
+    const ok = octokitWithContent(catalogYaml(['security', 'performance']));
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r');
+    const names = result.strategies.map((s) => s.name);
+    expect(names).toContain('security');
+    expect(names).toContain('performance');
+    expect(result.strategies).toHaveLength(2);
+    expect(result.notice).toBeUndefined();
+  });
+
+  it('omits configured strategies absent from the catalog, with a notice', async () => {
+    const ok = octokitWithContent(catalogYaml(['security', 'nope-missing']));
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r');
+    const names = result.strategies.map((s) => s.name);
+    expect(names).toEqual(['security']);
+    expect(result.notice).toMatch(/nope-missing/);
+  });
+
+  it('falls back to full-review with a notice when config is missing', async () => {
+    const ok = octokitWithContent({ notFound: true });
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r');
+    expect(result.strategies.map((s) => s.name)).toEqual(['full-review']);
+    expect(result.notice).toMatch(/no.*config|fall/i);
+  });
+
+  it('falls back to full-review with a notice when YAML is malformed', async () => {
+    const ok = octokitWithContent({ malformed: true });
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r');
+    expect(result.strategies.map((s) => s.name)).toEqual(['full-review']);
+    expect(result.notice).toMatch(/malform|fall/i);
+  });
+
+  it('returns the requested strategy when allowed and present', async () => {
+    const ok = octokitWithContent(catalogYaml(['security', 'performance']));
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r', 'performance');
+    expect(result.strategies.map((s) => s.name)).toEqual(['performance']);
+  });
+
+  it('errors when requested strategy is absent from the catalog', async () => {
+    const ok = octokitWithContent(catalogYaml(['security']));
+    await expect(
+      cleanStrategies.resolveForRepo(ok, 'o', 'r', 'ghost'),
+    ).rejects.toThrow(/available/i);
+  });
+
+  it('errors when requested strategy is not allowed by repo config', async () => {
+    const ok = octokitWithContent(catalogYaml(['security'], 'security'));
+    await expect(
+      cleanStrategies.resolveForRepo(ok, 'o', 'r', 'performance'),
+    ).rejects.toThrow(/not allowed|allowed/i);
+  });
+
+  it('uses config default when no strategy is requested and repo lists several', async () => {
+    const ok = octokitWithContent(catalogYaml(['security', 'performance'], 'performance'));
+    // No requested; default is performance → strategies filtered to catalog.
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r');
+    // With no explicit request, returns all allowed (intersected), not just default.
+    const names = result.strategies.map((s) => s.name);
+    expect(names).toContain('security');
+    expect(names).toContain('performance');
+  });
+
+  it('falls back to full-review when repo lists strategies but none match catalog', async () => {
+    const ok = octokitWithContent(catalogYaml(['unknown-1', 'unknown-2'], 'unknown-1'));
+    const result = await cleanStrategies.resolveForRepo(ok, 'o', 'r');
+    expect(result.strategies.map((s) => s.name)).toEqual(['full-review']);
+    expect(result.notice).toMatch(/fall/i);
+  });
+});
+

--- a/refactor/src/services/strategy.ts
+++ b/refactor/src/services/strategy.ts
@@ -15,8 +15,20 @@ import type { IStrategyService, Strategy, ResolvedStrategies, RepoConfig } from 
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
-/** Default catalog location: `refactor/strategies/`. */
-const DEFAULT_CATALOG_DIR = path.resolve(__dirname, '../../strategies');
+/**
+ * Default catalog location.
+ *
+ * In TS source execution, `__dirname` is `src/services` and `../../strategies`
+ * points at `refactor/strategies`. After `tsc`, `__dirname` is
+ * `dist/src/services`; the checked-in strategy files still live beside the
+ * package root, so fall back to `process.cwd()/strategies` for built/runtime
+ * deployments.
+ */
+function defaultCatalogDir(): string {
+  const sourceRelative = path.resolve(__dirname, '../../strategies');
+  if (fs.existsSync(sourceRelative)) return sourceRelative;
+  return path.resolve(process.cwd(), 'strategies');
+}
 
 export interface StrategyServiceOptions {
   /** Directory holding `*.md` strategy files. Defaults to `refactor/strategies`. */
@@ -32,7 +44,7 @@ export class StrategyService implements IStrategyService {
   private catalogCache: Map<string, Strategy> | undefined;
 
   constructor(opts: StrategyServiceOptions = {}) {
-    this.catalogDir = opts.catalogDir ?? DEFAULT_CATALOG_DIR;
+    this.catalogDir = opts.catalogDir ?? defaultCatalogDir();
     // Eager load so a broken catalog fails fast at boot.
     this.catalogCache = this.loadCatalog();
   }

--- a/refactor/src/services/strategy.ts
+++ b/refactor/src/services/strategy.ts
@@ -1,0 +1,122 @@
+/**
+ * Strategy service: loads the catalog of review strategies from
+ * `refactor/strategies/*.md`, parses skill-style frontmatter (gray-matter),
+ * and resolves a repository's configured strategies against the catalog.
+ *
+ * Catalog loading is synchronous-once and cached. Repo-config resolution
+ * (Phase 2.3) is added below.
+ */
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as url from 'node:url';
+import matter from 'gray-matter';
+import type { IStrategyService, Strategy, ResolvedStrategies } from '../types/index.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+
+/** Default catalog location: `refactor/strategies/`. */
+const DEFAULT_CATALOG_DIR = path.resolve(__dirname, '../../strategies');
+
+export interface StrategyServiceOptions {
+  /** Directory holding `*.md` strategy files. Defaults to `refactor/strategies`. */
+  catalogDir?: string;
+}
+
+/**
+ * Loads and caches the review-strategy catalog and resolves per-repo
+ * configurations against it.
+ */
+export class StrategyService implements IStrategyService {
+  private readonly catalogDir: string;
+  private catalogCache: Map<string, Strategy> | undefined;
+
+  constructor(opts: StrategyServiceOptions = {}) {
+    this.catalogDir = opts.catalogDir ?? DEFAULT_CATALOG_DIR;
+    // Eager load so a broken catalog fails fast at boot.
+    this.catalogCache = this.loadCatalog();
+  }
+
+  /** Returns the cached name→Strategy map. */
+  getCatalog(): Map<string, Strategy> {
+    return this.catalogCache as Map<string, Strategy>;
+  }
+
+  /**
+   * Resolves strategies for a repo against its `.github/review-config.yaml`.
+   * Implemented in Phase 2.3.
+   */
+  async resolveForRepo(
+    _octokit: unknown,
+    _owner: string,
+    _repo: string,
+    _requested?: string,
+  ): Promise<ResolvedStrategies> {
+    throw new Error('resolveForRepo not yet implemented (Phase 2.3)');
+  }
+
+  /** Loads and validates all `*.md` files from the catalog directory. */
+  private loadCatalog(): Map<string, Strategy> {
+    const catalog = new Map<string, Strategy>();
+    let entries: string[];
+    try {
+      entries = fs
+        .readdirSync(this.catalogDir)
+        .filter((f) => f.endsWith('.md'))
+        .sort();
+    } catch (err) {
+      throw new Error(
+        `Could not read strategy catalog at ${this.catalogDir}: ${(err as Error).message}`,
+      );
+    }
+
+    for (const file of entries) {
+      const filePath = path.join(this.catalogDir, file);
+      const raw = fs.readFileSync(filePath, 'utf8');
+      let parsed: matter.GrayMatterFile<string>;
+      try {
+        parsed = matter(raw);
+      } catch (err) {
+        throw new Error(
+          `Malformed frontmatter in strategy file ${file}: ${(err as Error).message}`,
+        );
+      }
+
+      const data = parsed.data as Record<string, unknown>;
+      const name = data.name;
+      const description = data.description;
+
+      if (typeof name !== 'string' || !name.trim()) {
+        throw new Error(`Strategy file ${file} is missing a 'name' in frontmatter.`);
+      }
+      if (typeof description !== 'string' || !description.trim()) {
+        throw new Error(
+          `Strategy file ${file} is missing a 'description' in frontmatter.`,
+        );
+      }
+      const body = parsed.content.trim();
+      if (!body) {
+        throw new Error(`Strategy file ${file} has an empty prompt body.`);
+      }
+
+      if (catalog.has(name)) {
+        throw new Error(
+          `Duplicate strategy name '${name}' found in ${file} (already defined elsewhere in the catalog).`,
+        );
+      }
+
+      const strategy: Strategy = {
+        name,
+        description,
+        triggers: Array.isArray(data.triggers)
+          ? (data.triggers as string[])
+          : undefined,
+        priority:
+          typeof data.priority === 'number' ? data.priority : undefined,
+        body,
+      };
+      catalog.set(name, strategy);
+    }
+
+    return catalog;
+  }
+}

--- a/refactor/src/services/strategy.ts
+++ b/refactor/src/services/strategy.ts
@@ -10,7 +10,8 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as url from 'node:url';
 import matter from 'gray-matter';
-import type { IStrategyService, Strategy, ResolvedStrategies } from '../types/index.js';
+import yaml from 'js-yaml';
+import type { IStrategyService, Strategy, ResolvedStrategies, RepoConfig } from '../types/index.js';
 
 const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
 
@@ -42,16 +43,143 @@ export class StrategyService implements IStrategyService {
   }
 
   /**
-   * Resolves strategies for a repo against its `.github/review-config.yaml`.
-   * Implemented in Phase 2.3.
+   * Fetches `.github/review-config.yaml` from the repo (via the installation
+   * Octokit), parses it, and intersects the repo's allowed strategy names
+   * with the catalog.
+   *
+   * - Missing config file → fall back to `full-review` with a notice.
+   * - Malformed YAML → fall back to `full-review` with a notice.
+   * - Requested strategy absent from catalog → error listing available.
+   * - Requested strategy present in catalog but not allowed by repo config
+   *   → error listing the repo's allowed strategies.
+   * - No request → returns all allowed strategies present in the catalog;
+   *   if none match, falls back to `full-review` with a notice.
    */
   async resolveForRepo(
-    _octokit: unknown,
-    _owner: string,
-    _repo: string,
-    _requested?: string,
+    octokit: unknown,
+    owner: string,
+    repo: string,
+    requested?: string,
   ): Promise<ResolvedStrategies> {
-    throw new Error('resolveForRepo not yet implemented (Phase 2.3)');
+    const catalog = this.getCatalog();
+    const { config, reason } = await this.fetchRepoConfig(octokit, owner, repo);
+
+    if (requested) {
+      if (!catalog.has(requested)) {
+        throw new Error(
+          `Unknown strategy '${requested}'. Available strategies: ${[...catalog.keys()].join(', ')}.`,
+        );
+      }
+      if (config && config.strategies.length > 0 && !config.strategies.includes(requested)) {
+        throw new Error(
+          `Strategy '${requested}' is not allowed by this repository's review-config.yaml. Allowed: ${config.strategies.join(', ')}.`,
+        );
+      }
+      return { strategies: [catalog.get(requested) as Strategy] };
+    }
+
+    if (!config) {
+      // Missing or unparseable config → fall back to full-review.
+      const fallback = catalog.get('full-review');
+      if (!fallback) {
+        throw new Error(
+          `No review-config.yaml found and no 'full-review' strategy exists in the catalog. Available: ${[...catalog.keys()].join(', ')}.`,
+        );
+      }
+      return {
+        strategies: [fallback],
+        notice:
+          reason === 'malformed'
+            ? 'Malformed .github/review-config.yaml; falling back to the default strategy full-review.'
+            : 'No .github/review-config.yaml found; falling back to the default strategy full-review.',
+      };
+    }
+
+    const matched = config.strategies
+      .filter((name) => catalog.has(name))
+      .map((name) => catalog.get(name) as Strategy);
+    const missing = config.strategies.filter((name) => !catalog.has(name));
+
+    if (matched.length === 0) {
+      const fallback = catalog.get('full-review');
+      if (!fallback) {
+        throw new Error(
+          `None of the configured strategies (${config.strategies.join(', ')}) exist in the catalog, and no 'full-review' fallback exists.`,
+        );
+      }
+      const notice =
+        missing.length > 0
+          ? `Configured strategies not in catalog: ${missing.join(', ')}. Falling back to full-review.`
+          : 'No matching strategies found in the catalog. Falling back to full-review.';
+      return { strategies: [fallback], notice };
+    }
+
+    const notice =
+      missing.length > 0
+        ? `Configured strategies not in catalog (ignored): ${missing.join(', ')}.`
+        : undefined;
+    return { strategies: matched, notice };
+  }
+
+  /** Fetches and parses `.github/review-config.yaml`; returns null on missing/malformed. */
+  private async fetchRepoConfig(
+    octokit: unknown,
+    owner: string,
+    repo: string,
+  ): Promise<{ config: RepoConfig | null; reason?: 'missing' | 'malformed' }> {
+    const api = octokit as {
+      rest: {
+        repos: {
+          getContent(params: {
+            owner: string;
+            repo: string;
+            path: string;
+          }): Promise<{
+            data:
+              | { type: string; content?: string; encoding?: string }
+              | Array<unknown>;
+          }>;
+        };
+      };
+    };
+    const CONFIG_PATH = '.github/review-config.yaml';
+
+    let data: { type: string; content?: string; encoding?: string } | null = null;
+    try {
+      const res = await api.rest.repos.getContent({ owner, repo, path: CONFIG_PATH });
+      if (!Array.isArray(res.data) && res.data.type === 'file') {
+        data = res.data;
+      }
+    } catch (err) {
+      const status = (err as Error & { status?: number }).status;
+      if (status === 404) return { config: null, reason: 'missing' };
+      throw new Error(
+        `Failed to read review-config.yaml from ${owner}/${repo}: ${(err as Error).message}`,
+      );
+    }
+    if (!data) return { config: null, reason: 'missing' };
+
+    const raw = data.content ?? '';
+    const text = data.encoding === 'base64'
+      ? Buffer.from(raw, 'base64').toString('utf8')
+      : raw;
+    try {
+      const parsed = yaml.load(text) as Partial<RepoConfig> | null;
+      return { config: this.normalizeConfig(parsed) };
+    } catch {
+      // Malformed YAML → signal fallback.
+      return { config: null, reason: 'malformed' };
+    }
+  }
+
+  private normalizeConfig(parsed: Partial<RepoConfig> | null): RepoConfig | null {
+    if (!parsed) return null;
+    const strategies = Array.isArray(parsed.strategies)
+      ? (parsed.strategies as unknown[]).filter(
+          (s): s is string => typeof s === 'string' && s.trim() !== '',
+        )
+      : [];
+    return { strategies, default: parsed.default };
   }
 
   /** Loads and validates all `*.md` files from the catalog directory. */

--- a/refactor/src/tools/analyze_code_quality.ts
+++ b/refactor/src/tools/analyze_code_quality.ts
@@ -1,0 +1,49 @@
+/**
+ * Tool: analyze_code_quality
+ *
+ * Runs data-only heuristic quality analysis over PR patches. No LLM calls.
+ */
+
+import { AnalysisService } from '../services/analysis.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+
+export function registerAnalyzeCodeQuality(): void {
+  registerTool({
+    definition: {
+      name: 'analyze_code_quality',
+      description:
+        'Analyze code quality metrics for changed files including complexity, maintainability, technical debt, issues, and suggestions.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: { type: 'string', description: 'GitHub PR URL.' },
+          file_paths: {
+            type: 'array',
+            items: { type: 'string' },
+            description: 'Optional subset of changed file paths to analyze.',
+          },
+        },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (args: Record<string, unknown>, services: ToolServices): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for analyze_code_quality.');
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved as ToolResult;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const details = await github.getPRDetails(prUrl);
+        const filePaths = Array.isArray(args.file_paths) ? (args.file_paths as string[]) : null;
+        return jsonResult(new AnalysisService().analyzeCodeQuality(details, filePaths));
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/analyze_dependencies.ts
+++ b/refactor/src/tools/analyze_dependencies.ts
@@ -1,0 +1,41 @@
+/**
+ * Tool: analyze_dependencies
+ *
+ * Runs data-only heuristic dependency-change analysis over PR changed files.
+ */
+
+import { AnalysisService } from '../services/analysis.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+
+export function registerAnalyzeDependencies(): void {
+  registerTool({
+    definition: {
+      name: 'analyze_dependencies',
+      description:
+        'Analyze dependency manifest and lockfile changes, returning security/licensing review recommendations.',
+      inputSchema: {
+        type: 'object',
+        properties: { pr_url: { type: 'string', description: 'GitHub PR URL.' } },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (args: Record<string, unknown>, services: ToolServices): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for analyze_dependencies.');
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved as ToolResult;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const details = await github.getPRDetails(prUrl);
+        return jsonResult(new AnalysisService().analyzeDependencies(details));
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/analyze_diff_impact.ts
+++ b/refactor/src/tools/analyze_diff_impact.ts
@@ -1,0 +1,41 @@
+/**
+ * Tool: analyze_diff_impact
+ *
+ * Runs data-only heuristic impact/risk analysis over PR changed files.
+ */
+
+import { AnalysisService } from '../services/analysis.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+
+export function registerAnalyzeDiffImpact(): void {
+  registerTool({
+    definition: {
+      name: 'analyze_diff_impact',
+      description:
+        'Analyze the impact and risk of PR changes, including configuration/security-sensitive areas and deployment recommendations.',
+      inputSchema: {
+        type: 'object',
+        properties: { pr_url: { type: 'string', description: 'GitHub PR URL.' } },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (args: Record<string, unknown>, services: ToolServices): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for analyze_diff_impact.');
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved as ToolResult;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const details = await github.getPRDetails(prUrl);
+        return jsonResult(new AnalysisService().analyzeDiffImpact(details));
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/analyze_test_coverage.ts
+++ b/refactor/src/tools/analyze_test_coverage.ts
@@ -1,0 +1,41 @@
+/**
+ * Tool: analyze_test_coverage
+ *
+ * Runs data-only heuristic test coverage analysis over PR changed files.
+ */
+
+import { AnalysisService } from '../services/analysis.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+
+export function registerAnalyzeTestCoverage(): void {
+  registerTool({
+    definition: {
+      name: 'analyze_test_coverage',
+      description:
+        'Estimate test coverage for PR changes by comparing changed test files to changed production files.',
+      inputSchema: {
+        type: 'object',
+        properties: { pr_url: { type: 'string', description: 'GitHub PR URL.' } },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (args: Record<string, unknown>, services: ToolServices): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for analyze_test_coverage.');
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved as ToolResult;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const details = await github.getPRDetails(prUrl);
+        return jsonResult(new AnalysisService().analyzeTestCoverage(details));
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/core.tools.test.ts
+++ b/refactor/src/tools/core.tools.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  registerAllTools,
+  getTool,
+  resetRegistry,
+} from './index.js';
+import type { ToolServices } from '../types/index.js';
+
+/** Mock GitHubService-like object exposing the methods handlers touch. */
+function makeGithubMock(overrides: Partial<{
+  getPRDetails: ReturnType<typeof vi.fn>;
+  getPRFiles: ReturnType<typeof vi.fn>;
+  getPRCommits: ReturnType<typeof vi.fn>;
+  getFileContent: ReturnType<typeof vi.fn>;
+  getDiffRange: ReturnType<typeof vi.fn>;
+  createReview: ReturnType<typeof vi.fn>;
+  getRepoInfo: ReturnType<typeof vi.fn>;
+  parsePRURL: ReturnType<typeof vi.fn>;
+}> = {}) {
+  return {
+    getPRDetails: overrides.getPRDetails ?? vi.fn(async () => ({ pr: {}, files: [], commits: [], existing_reviews: [], repository: {} })),
+    getPRFiles: overrides.getPRFiles ?? vi.fn(async () => []),
+    getPRCommits: overrides.getPRCommits ?? vi.fn(async () => []),
+    getFileContent: overrides.getFileContent ?? vi.fn(async () => null),
+    getDiffRange: overrides.getDiffRange ?? vi.fn(async () => ({ base_sha: 'b', head_sha: 'h', total_commits: 1, total_files: 1, files: [] })),
+    createReview: overrides.createReview ?? vi.fn(async () => ({ success: true, review_id: 7, review_url: 'u' })),
+    getRepoInfo: overrides.getRepoInfo ?? vi.fn(async () => ({ owner: 'o', repo: 'r', full_name: 'o/r', languages: {}, primary_language: 'None', has_readme: false, readme_content: null })),
+    parsePRURL: overrides.parsePRURL ?? vi.fn((u: string) => {
+      const m = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/.exec(u);
+      return { owner: m[1], repo: m[2], pull_number: parseInt(m[3], 10) };
+    }),
+  };
+}
+
+const PR_URL = 'https://github.com/octo/repo/pull/42';
+
+function makeServices(githubMock: ReturnType<typeof makeGithubMock>, allowAll = true): ToolServices {
+  return {
+    config: {
+      isRepoAllowed: vi.fn(() => allowAll),
+    } as never,
+    githubApp: {
+      getInstallationOctokit: vi.fn(async () => ({})),
+    } as never,
+    strategy: {} as never,
+    __githubMock: githubMock,
+  } as never as ToolServices;
+}
+
+// Build services where installation Octokit resolves to `githubMock`.
+// We patch `buildGitHub` usage by having github-app return the mock
+// directly (handlers wrap octokit via new GitHubService(octokit); pass a mock
+// that *is* GitHubService-shaped).
+function makeServicesWithMock(githubMock: ReturnType<typeof makeGithubMock>, allowAll = true) {
+  const services: ToolServices = {
+    config: {
+      isRepoAllowed: vi.fn(() => allowAll),
+      githubAppId: 'a', githubAppPrivateKey: 'p', mcpApiSecret: 's',
+      port: 3000, maxPatchSize: 1000, maxFilesToReview: 100, requestTimeout: 60,
+      toDebugObject: () => ({}),
+    } as never,
+    githubApp: {
+      getInstallationOctokit: vi.fn(async () => githubMock),
+    } as never,
+    strategy: {} as never,
+  } as never as ToolServices;
+  return services;
+}
+
+describe('tool handlers (core delegation)', () => {
+  beforeEach(() => {
+    resetRegistry();
+    registerAllTools();
+  });
+
+  it('registers at least 8 core tools', () => {
+    const names = ['get_pr_details', 'get_pr_files', 'get_pr_commits', 'get_file_content', 'post_pr_review', 'get_repo_info', 'get_pr_diff_range', 'get_review_strategy'];
+    for (const n of names) {
+      expect(getTool(n), `expect ${n} registered`).toBeDefined();
+    }
+  });
+
+  it('get_pr_details enforces allowlist before GitHub call', async () => {
+    const mock = makeGithubMock();
+    const services = makeServicesWithMock(mock, false);
+    const entry = getTool('get_pr_details')!;
+    const result = await entry.handler({ pr_url: PR_URL }, services);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/allowlist/i);
+    expect(mock.getPRDetails).not.toHaveBeenCalled();
+  });
+
+  it('get_pr_details returns JSON payload', async () => {
+    const mock = makeGithubMock({
+      getPRDetails: vi.fn(async () => ({ pr: { number: 42 }, files: [{filename:'a'}], commits: [], existing_reviews: [], repository: {full_name:'octo/repo'} })),
+    });
+    const services = makeServicesWithMock(mock);
+    const entry = getTool('get_pr_details')!;
+    const result = await entry.handler({ pr_url: PR_URL }, services);
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0].text).toContain('"number": 42');
+  });
+
+  it('get_pr_diff_range returns the diff range', async () => {
+    const mock = makeGithubMock({
+      getDiffRange: vi.fn(async () => ({ base_sha: 'b1', head_sha: 'h1', total_commits: 2, total_files: 3, files: [{filename:'x.js'}] })),
+    });
+    const services = makeServicesWithMock(mock);
+    const entry = getTool('get_pr_diff_range')!;
+    const result = await entry.handler({ owner: 'octo', repo: 'repo', base_sha: 'b1', head_sha: 'h1' }, services);
+    expect(mock.getDiffRange).toHaveBeenCalledWith('octo', 'repo', 'b1', 'h1');
+    expect(result.content[0].text).toContain('"total_commits": 2');
+  });
+
+  it('post_pr_review maps inline comments to createReview comments', async () => {
+    const mock = makeGithubMock({
+      createReview: vi.fn(async () => ({ success: true, review_id: 999, review_url: 'https://gh/r' })),
+    });
+    const services = makeServicesWithMock(mock);
+    const entry = getTool('post_pr_review')!;
+    const result = await entry.handler({
+      pr_url: PR_URL,
+      body: 'LGTM',
+      event: 'APPROVE',
+      comments: [
+        { path: 'a.js', line: 12, body: 'good', side: 'RIGHT', start_line: 8 },
+      ],
+    }, services);
+    expect(result.content[0].text).toContain('"review_id": 999');
+    expect(mock.createReview).toHaveBeenCalledWith('octo', 'repo', 42, {
+      body: 'LGTM',
+      event: 'APPROVE',
+      comments: [{ path: 'a.js', line: 12, body: 'good', side: 'RIGHT', start_line: 8 }],
+    });
+  });
+
+  it('get_file_content rejects missing args', async () => {
+    const mock = makeGithubMock();
+    const services = makeServicesWithMock(mock);
+    const entry = getTool('get_file_content')!;
+    const result = await entry.handler({ path: 'a' }, services);
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/owner|repo|required/i);
+  });
+
+  it('get_review_strategy resolves strategies and emits notice', async () => {
+    const strategy = {
+      resolveForRepo: vi.fn(async () => ({ strategies: [{name:'security', description:'d', body:'b'}], notice: 'n' })),
+    };
+    const services = makeServicesWithMock(makeGithubMock());
+    services.strategy = strategy as never;
+    const entry = getTool('get_review_strategy')!;
+    const result = await entry.handler({ pr_url: PR_URL, strategy: 'security' }, services);
+    expect(result.content[0].text).toContain('"name": "security"');
+    expect(result.content[0].text).toContain('"notice": "n"');
+    expect(strategy.resolveForRepo).toHaveBeenCalled();
+  });
+});

--- a/refactor/src/tools/detect_code_patterns.ts
+++ b/refactor/src/tools/detect_code_patterns.ts
@@ -1,0 +1,48 @@
+/**
+ * Tool: detect_code_patterns
+ *
+ * Runs data-only regex-based pattern/anti-pattern detection over PR patches.
+ */
+
+import { AnalysisService } from '../services/analysis.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+
+export function registerDetectCodePatterns(): void {
+  registerTool({
+    definition: {
+      name: 'detect_code_patterns',
+      description:
+        'Detect good patterns and anti-patterns in PR patches using data-only regex heuristics.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: { type: 'string', description: 'GitHub PR URL.' },
+          language: {
+            type: 'string',
+            description: 'Optional language override used in the result metadata.',
+          },
+        },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (args: Record<string, unknown>, services: ToolServices): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for detect_code_patterns.');
+      const language = (args.language as string | undefined) ?? null;
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved as ToolResult;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const details = await github.getPRDetails(prUrl);
+        return jsonResult(new AnalysisService().detectCodePatterns(details, language));
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/detect_security_issues.ts
+++ b/refactor/src/tools/detect_security_issues.ts
@@ -1,0 +1,41 @@
+/**
+ * Tool: detect_security_issues
+ *
+ * Runs data-only regex-based security scanning over added PR patch lines.
+ */
+
+import { AnalysisService } from '../services/analysis.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+
+export function registerDetectSecurityIssues(): void {
+  registerTool({
+    definition: {
+      name: 'detect_security_issues',
+      description:
+        'Detect potential security issues in PR patches using data-only regex heuristics (secrets, SQL injection, XSS, eval, insecure randomness).',
+      inputSchema: {
+        type: 'object',
+        properties: { pr_url: { type: 'string', description: 'GitHub PR URL.' } },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (args: Record<string, unknown>, services: ToolServices): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for detect_security_issues.');
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved as ToolResult;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const details = await github.getPRDetails(prUrl);
+        return jsonResult(new AnalysisService().detectSecurityIssues(details));
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_file_content.ts
+++ b/refactor/src/tools/get_file_content.ts
@@ -1,0 +1,76 @@
+/**
+ * Tool: get_file_content
+ *
+ * Fetches the decoded text content of a file in a repository at an optional
+ * git ref. Requires owner + repo + path (no PR URL) so callers can inspect
+ * files outside the PR diff.
+ */
+
+import { registerTool } from './registry.js';
+import {
+  buildGitHub,
+  enforceAllowlist,
+  errorResult,
+  jsonResult,
+} from './shared.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetFileContent(): void {
+  registerTool({
+    definition: {
+      name: 'get_file_content',
+      description:
+        'Fetch the decoded text content of a file in a repository at an optional git ref.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: { type: 'string', description: 'Repository owner.' },
+          repo: { type: 'string', description: 'Repository name.' },
+          path: {
+            type: 'string',
+            description: 'File path relative to the repository root.',
+          },
+          ref: {
+            type: 'string',
+            description:
+              'Optional git ref (branch, tag, or commit SHA). Defaults to the repo default branch.',
+          },
+        },
+        required: ['owner', 'repo', 'path'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const owner = args.owner as string | undefined;
+      const repo = args.repo as string | undefined;
+      const path = args.path as string | undefined;
+      const ref = args.ref as string | undefined;
+
+      if (!owner || !repo || !path) {
+        return errorResult(
+          'owner, repo, and path are required for get_file_content.',
+        );
+      }
+
+      const denied = enforceAllowlist(services, owner, repo);
+      if (denied) return denied;
+
+      try {
+        const github = await buildGitHub(services, owner, repo);
+        const content = await github.getFileContent(owner, repo, path, ref);
+        return jsonResult({
+          owner,
+          repo,
+          path,
+          ref: ref ?? null,
+          found: content !== null,
+          content,
+        });
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_pr_commits.ts
+++ b/refactor/src/tools/get_pr_commits.ts
@@ -1,0 +1,49 @@
+/**
+ * Tool: get_pr_commits
+ *
+ * Returns the list of commits in a pull request (sha, message, author, date).
+ */
+
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetPRCommits(): void {
+  registerTool({
+    definition: {
+      name: 'get_pr_commits',
+      description:
+        'Get the list of commits in a pull request (sha, message, author, date).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: {
+            type: 'string',
+            description:
+              'GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)',
+          },
+        },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for get_pr_commits.');
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const commits = await github.getPRCommits(prUrl);
+        return jsonResult({ pr_url: prUrl, total_commits: commits.length, commits });
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_pr_details.ts
+++ b/refactor/src/tools/get_pr_details.ts
@@ -1,0 +1,53 @@
+/**
+ * Tool: get_pr_details
+ *
+ * Returns comprehensive PR metadata including title, description, files changed,
+ * commits, existing reviews, and repository info.
+ */
+
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetPRDetails(): void {
+  registerTool({
+    definition: {
+      name: 'get_pr_details',
+      description:
+        'Get comprehensive PR metadata including title, description, files changed, commits, existing reviews, and repository info.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: {
+            type: 'string',
+            description:
+              'GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)',
+          },
+        },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string;
+      if (!prUrl) {
+        return errorResult('pr_url is required for get_pr_details.');
+      }
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) {
+        return resolved as ToolResult;
+      }
+
+      const { github } = resolved as { github: import('../services/github.js').GitHubService };
+      try {
+        const details = await github.getPRDetails(prUrl);
+        return jsonResult(details);
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_pr_diff_range.ts
+++ b/refactor/src/tools/get_pr_diff_range.ts
@@ -1,0 +1,68 @@
+/**
+ * Tool: get_pr_diff_range
+ *
+ * Compares two commit SHAs in a repository and returns the aggregate diff
+ * (total commits, total files, per-file patches). Useful for reviewing only
+ * the commits pushed since a previous review (incremental review).
+ */
+
+import { registerTool } from './registry.js';
+import {
+  buildGitHub,
+  enforceAllowlist,
+  errorResult,
+  jsonResult,
+} from './shared.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetPRDiffRange(): void {
+  registerTool({
+    definition: {
+      name: 'get_pr_diff_range',
+      description:
+        'Compare two commit SHAs in a repository and return the aggregate diff (total commits, total files, per-file patches).',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: { type: 'string', description: 'Repository owner.' },
+          repo: { type: 'string', description: 'Repository name.' },
+          base_sha: {
+            type: 'string',
+            description: 'Base commit SHA the comparison starts from.',
+          },
+          head_sha: {
+            type: 'string',
+            description: 'Head commit SHA the comparison ends at.',
+          },
+        },
+        required: ['owner', 'repo', 'base_sha', 'head_sha'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const owner = args.owner as string | undefined;
+      const repo = args.repo as string | undefined;
+      const baseSha = args.base_sha as string | undefined;
+      const headSha = args.head_sha as string | undefined;
+
+      if (!owner || !repo || !baseSha || !headSha) {
+        return errorResult(
+          'owner, repo, base_sha, and head_sha are required for get_pr_diff_range.',
+        );
+      }
+
+      const denied = enforceAllowlist(services, owner, repo);
+      if (denied) return denied;
+
+      try {
+        const github = await buildGitHub(services, owner, repo);
+        const range = await github.getDiffRange(owner, repo, baseSha, headSha);
+        return jsonResult(range);
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_pr_files.ts
+++ b/refactor/src/tools/get_pr_files.ts
@@ -1,0 +1,57 @@
+/**
+ * Tool: get_pr_files
+ *
+ * Returns the list of files changed in a pull request, optionally including
+ * the unified diff patch for each file.
+ */
+
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+import type { GitHubService } from '../services/github.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetPRFiles(): void {
+  registerTool({
+    definition: {
+      name: 'get_pr_files',
+      description:
+        'Get the list of files changed in a pull request, optionally including the unified diff patch for each file.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: {
+            type: 'string',
+            description:
+              'GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)',
+          },
+          include_patch: {
+            type: 'boolean',
+            description:
+              'Whether to include the unified diff patch for each file (default: true).',
+          },
+        },
+        required: ['pr_url'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      if (!prUrl) return errorResult('pr_url is required for get_pr_files.');
+      const includePatch =
+        args.include_patch === undefined ? true : Boolean(args.include_patch);
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved;
+      const { github } = resolved as { github: GitHubService };
+
+      try {
+        const files = await github.getPRFiles(prUrl, includePatch);
+        return jsonResult({ pr_url: prUrl, total_files: files.length, files });
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_repo_info.ts
+++ b/refactor/src/tools/get_repo_info.ts
@@ -1,0 +1,55 @@
+/**
+ * Tool: get_repo_info
+ *
+ * Returns repository metadata: language breakdown, primary language, and
+ * README content (decoded).
+ */
+
+import { registerTool } from './registry.js';
+import {
+  buildGitHub,
+  enforceAllowlist,
+  errorResult,
+  jsonResult,
+} from './shared.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetRepoInfo(): void {
+  registerTool({
+    definition: {
+      name: 'get_repo_info',
+      description:
+        'Get repository metadata: language breakdown, primary language, and README content.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          owner: { type: 'string', description: 'Repository owner.' },
+          repo: { type: 'string', description: 'Repository name.' },
+        },
+        required: ['owner', 'repo'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const owner = args.owner as string | undefined;
+      const repo = args.repo as string | undefined;
+
+      if (!owner || !repo) {
+        return errorResult('owner and repo are required for get_repo_info.');
+      }
+
+      const denied = enforceAllowlist(services, owner, repo);
+      if (denied) return denied;
+
+      try {
+        const github = await buildGitHub(services, owner, repo);
+        const info = await github.getRepoInfo(owner, repo);
+        return jsonResult(info);
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/get_review_strategy.ts
+++ b/refactor/src/tools/get_review_strategy.ts
@@ -1,0 +1,96 @@
+/**
+ * Tool: get_review_strategy
+ *
+ * Resolves review strategy prompt(s) for a repository by reading the repo's
+ * `.github/review-config.yaml` and intersecting with the local strategy
+ * catalog. Returns the matched strategy prompt(s) for the n8n agent to use.
+ */
+
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, enforceAllowlist } from './shared.js';
+import { GitHubService } from '../services/github.js';
+import type { ToolServices, ToolResult } from '../types/index.js';
+
+export function registerGetReviewStrategy(): void {
+  registerTool({
+    definition: {
+      name: 'get_review_strategy',
+      description:
+        'Resolve review strategy prompt(s) for a repository. Reads .github/review-config.yaml and intersects with the local strategy catalog. Returns the matched strategy prompt(s) for the n8n agent to use.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: {
+            type: 'string',
+            description:
+              'GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)',
+          },
+          owner: {
+            type: 'string',
+            description: 'Repository owner (alternative to pr_url)',
+          },
+          repo: {
+            type: 'string',
+            description: 'Repository name (alternative to pr_url)',
+          },
+          strategy: {
+            type: 'string',
+            description:
+              'Optional specific strategy name to request. If omitted, returns all strategies allowed by the repo config.',
+          },
+        },
+        required: [],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      const owner = args.owner as string | undefined;
+      const repo = args.repo as string | undefined;
+      const requested = args.strategy as string | undefined;
+
+      let resolvedOwner: string;
+      let resolvedRepo: string;
+
+      if (prUrl) {
+        try {
+          const gh = new GitHubService({} as never);
+          const pr = gh.parsePRURL(prUrl);
+          resolvedOwner = pr.owner;
+          resolvedRepo = pr.repo;
+        } catch (err) {
+          return errorResult((err as Error).message);
+        }
+      } else if (owner && repo) {
+        resolvedOwner = owner;
+        resolvedRepo = repo;
+      } else {
+        return errorResult(
+          'Either pr_url or owner+repo is required for get_review_strategy.',
+        );
+      }
+
+      const denied = enforceAllowlist(services, resolvedOwner, resolvedRepo);
+      if (denied) return denied;
+
+      const octokit = await services.githubApp.getInstallationOctokit(
+        resolvedOwner,
+        resolvedRepo,
+      );
+
+      try {
+        const resolved = await services.strategy.resolveForRepo(
+          octokit,
+          resolvedOwner,
+          resolvedRepo,
+          requested,
+        );
+        return jsonResult(resolved);
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/index.test.ts
+++ b/refactor/src/tools/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest';
+import {
+  registerTool,
+  getTool,
+  toolDefinitions,
+  resetRegistry,
+} from './index.js';
+import type { ToolEntry } from './index.js';
+import type { ToolResult, ToolServices } from '../types/index.js';
+
+const fakeEntry = (name: string): ToolEntry => ({
+  definition: {
+    name,
+    description: `Tool ${name}`,
+    inputSchema: { type: 'object', properties: {} },
+  },
+  handler: async () => ({ content: [{ type: 'text', text: 'ok' }] }) as ToolResult,
+});
+
+describe('tool registry', () => {
+  // Ensure a clean slate regardless of other modules' side effects.
+  resetRegistry();
+
+  it('starts empty', () => {
+    expect(toolDefinitions).toEqual([]);
+    expect(getTool('nope')).toBeUndefined();
+  });
+
+  it('registerTool adds to definitions and lookup', () => {
+    registerTool(fakeEntry('alpha'));
+    expect(toolDefinitions).toHaveLength(1);
+    expect(getTool('alpha')).toBeDefined();
+    expect(getTool('alpha')!.definition.name).toBe('alpha');
+  });
+
+  it('prevents duplicate registration', () => {
+    expect(() => registerTool(fakeEntry('alpha'))).toThrow(/already/);
+  });
+
+  it('handler can be invoked via the registry', async () => {
+    const entry = getTool('alpha')!;
+    const result = await entry.handler({} as Record<string, unknown>, {} as ToolServices);
+    expect(result.content[0].text).toBe('ok');
+  });
+
+  it('resetRegistry clears all entries', () => {
+    registerTool(fakeEntry('beta'));
+    expect(toolDefinitions).toHaveLength(2);
+    resetRegistry();
+    expect(toolDefinitions).toEqual([]);
+  });
+});

--- a/refactor/src/tools/index.ts
+++ b/refactor/src/tools/index.ts
@@ -1,0 +1,73 @@
+/**
+ * Tool registry — typed catalogue of MCP tools available to the server.
+ *
+ * Each tool registers a `{ definition, handler }` entry. The server's
+ * `ListTools` handler iterates `toolDefinitions`; the `CallTool` handler
+ * looks up the entry in `getTool` and invokes the handler with the resolved
+ * service bundle.
+ *
+ * Keeping the registry a mutable singleton (rather than a frozen map) lets
+ * individual tool modules self-register at import time: the server imports
+ * `./tools/index.js` (which in turn imports each tool module) and the
+ * registry is populated as a side effect.
+ */
+
+import type {
+  ToolDefinition,
+  ToolResult,
+  ToolServices,
+} from '../types/index.js';
+
+/**
+ * Synchronous handler invoked by `CallTool` with the typed args object and
+ * the resolved service bundle. Handlers must:
+ *   - enforce the repo allowlist before any GitHub call;
+ *   - return a `ToolResult` envelope (`{ content: [{ type: 'text', text }] }`);
+ *   - set `isError: true` on user-facing errors (allowlist, bad args, etc.).
+ */
+export type ToolHandler = (
+  args: Record<string, unknown>,
+  services: ToolServices,
+) => Promise<ToolResult>;
+
+export interface ToolEntry {
+  definition: ToolDefinition;
+  handler: ToolHandler;
+}
+
+const registry = new Map<string, ToolEntry>();
+
+/**
+ * Ordered list of tool definitions registered so far.
+ * Reassign on each access so callers always see the current snapshot.
+ */
+export const toolDefinitions: ToolDefinition[] = [];
+
+/**
+ * Register a tool. Throws if a tool with the same name is already registered.
+ */
+export function registerTool(entry: ToolEntry): void {
+  if (registry.has(entry.definition.name)) {
+    throw new Error(
+      `Tool '${entry.definition.name}' is already registered`,
+    );
+  }
+  registry.set(entry.definition.name, entry);
+  toolDefinitions.push(entry.definition);
+}
+
+/**
+ * Look up a tool by name. Returns `undefined` when not found.
+ */
+export function getTool(name: string): ToolEntry | undefined {
+  return registry.get(name);
+}
+
+/**
+ * Clears every registered tool. Intended for tests that need an isolated
+ * registry; production code never calls this.
+ */
+export function resetRegistry(): void {
+  registry.clear();
+  toolDefinitions.length = 0;
+}

--- a/refactor/src/tools/index.ts
+++ b/refactor/src/tools/index.ts
@@ -16,6 +16,8 @@ export {
 } from './registry.js';
 export type { ToolHandler, ToolEntry } from './registry.js';
 
+import { resetRegistry } from './registry.js';
+
 import { registerGetReviewStrategy } from './get_review_strategy.js';
 import { registerGetPRDetails } from './get_pr_details.js';
 import { registerGetPRFiles } from './get_pr_files.js';
@@ -35,6 +37,7 @@ import { registerDetectCodePatterns } from './detect_code_patterns.js';
  * Register every tool. Safe to call after `resetRegistry()`.
  */
 export function registerAllTools(): void {
+  resetRegistry();
   registerGetReviewStrategy();
   registerGetPRDetails();
   registerGetPRFiles();

--- a/refactor/src/tools/index.ts
+++ b/refactor/src/tools/index.ts
@@ -1,73 +1,52 @@
 /**
- * Tool registry — typed catalogue of MCP tools available to the server.
+ * Tool registry aggregator.
  *
- * Each tool registers a `{ definition, handler }` entry. The server's
- * `ListTools` handler iterates `toolDefinitions`; the `CallTool` handler
- * looks up the entry in `getTool` and invokes the handler with the resolved
- * service bundle.
+ * Re-exports the registry primitives and provides `registerAllTools()` which
+ * calls each individual tool module's `register()` function.
  *
- * Keeping the registry a mutable singleton (rather than a frozen map) lets
- * individual tool modules self-register at import time: the server imports
- * `./tools/index.js` (which in turn imports each tool module) and the
- * registry is populated as a side effect.
+ * The server calls `registerAllTools()` once at boot; tests call
+ * `resetRegistry()` + `registerAllTools()` before each test run.
  */
 
-import type {
-  ToolDefinition,
-  ToolResult,
-  ToolServices,
-} from '../types/index.js';
+export {
+  registerTool,
+  getTool,
+  toolDefinitions,
+  resetRegistry,
+} from './registry.js';
+export type { ToolHandler, ToolEntry } from './registry.js';
+
+import { registerGetReviewStrategy } from './get_review_strategy.js';
+import { registerGetPRDetails } from './get_pr_details.js';
+import { registerGetPRFiles } from './get_pr_files.js';
+import { registerGetPRCommits } from './get_pr_commits.js';
+import { registerGetFileContent } from './get_file_content.js';
+import { registerGetRepoInfo } from './get_repo_info.js';
+import { registerGetPRDiffRange } from './get_pr_diff_range.js';
+import { registerPostPRReview } from './post_pr_review.js';
+import { registerAnalyzeCodeQuality } from './analyze_code_quality.js';
+import { registerAnalyzeDiffImpact } from './analyze_diff_impact.js';
+import { registerAnalyzeDependencies } from './analyze_dependencies.js';
+import { registerAnalyzeTestCoverage } from './analyze_test_coverage.js';
+import { registerDetectSecurityIssues } from './detect_security_issues.js';
+import { registerDetectCodePatterns } from './detect_code_patterns.js';
 
 /**
- * Synchronous handler invoked by `CallTool` with the typed args object and
- * the resolved service bundle. Handlers must:
- *   - enforce the repo allowlist before any GitHub call;
- *   - return a `ToolResult` envelope (`{ content: [{ type: 'text', text }] }`);
- *   - set `isError: true` on user-facing errors (allowlist, bad args, etc.).
+ * Register every tool. Safe to call after `resetRegistry()`.
  */
-export type ToolHandler = (
-  args: Record<string, unknown>,
-  services: ToolServices,
-) => Promise<ToolResult>;
-
-export interface ToolEntry {
-  definition: ToolDefinition;
-  handler: ToolHandler;
-}
-
-const registry = new Map<string, ToolEntry>();
-
-/**
- * Ordered list of tool definitions registered so far.
- * Reassign on each access so callers always see the current snapshot.
- */
-export const toolDefinitions: ToolDefinition[] = [];
-
-/**
- * Register a tool. Throws if a tool with the same name is already registered.
- */
-export function registerTool(entry: ToolEntry): void {
-  if (registry.has(entry.definition.name)) {
-    throw new Error(
-      `Tool '${entry.definition.name}' is already registered`,
-    );
-  }
-  registry.set(entry.definition.name, entry);
-  toolDefinitions.push(entry.definition);
-}
-
-/**
- * Look up a tool by name. Returns `undefined` when not found.
- */
-export function getTool(name: string): ToolEntry | undefined {
-  return registry.get(name);
-}
-
-/**
- * Clears every registered tool. Intended for tests that need an isolated
- * registry; production code never calls this.
- */
-export function resetRegistry(): void {
-  registry.clear();
-  toolDefinitions.length = 0;
+export function registerAllTools(): void {
+  registerGetReviewStrategy();
+  registerGetPRDetails();
+  registerGetPRFiles();
+  registerGetPRCommits();
+  registerGetFileContent();
+  registerGetRepoInfo();
+  registerGetPRDiffRange();
+  registerPostPRReview();
+  registerAnalyzeCodeQuality();
+  registerAnalyzeDiffImpact();
+  registerAnalyzeDependencies();
+  registerAnalyzeTestCoverage();
+  registerDetectSecurityIssues();
+  registerDetectCodePatterns();
 }

--- a/refactor/src/tools/post_pr_review.ts
+++ b/refactor/src/tools/post_pr_review.ts
@@ -1,0 +1,110 @@
+/**
+ * Tool: post_pr_review
+ *
+ * Posts a review on a pull request: a top-level body, a review event
+ * (APPROVE / REQUEST_CHANGES / COMMENT), and optional inline line comments.
+ */
+
+import { registerTool } from './registry.js';
+import { errorResult, jsonResult, resolvePR } from './shared.js';
+import type { GitHubService } from '../services/github.js';
+import type {
+  ToolServices,
+  ToolResult,
+  InlineComment,
+  ReviewInput,
+} from '../types/index.js';
+
+const VALID_EVENTS = new Set(['APPROVE', 'REQUEST_CHANGES', 'COMMENT']);
+
+export function registerPostPRReview(): void {
+  registerTool({
+    definition: {
+      name: 'post_pr_review',
+      description:
+        'Post a review on a pull request: a top-level body, a review event (APPROVE / REQUEST_CHANGES / COMMENT), and optional inline line comments.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          pr_url: {
+            type: 'string',
+            description:
+              'GitHub PR URL (e.g., https://github.com/owner/repo/pull/123)',
+          },
+          body: { type: 'string', description: 'Review summary body (Markdown).' },
+          event: {
+            type: 'string',
+            enum: ['APPROVE', 'REQUEST_CHANGES', 'COMMENT'],
+            description: 'Review event type (default: COMMENT).',
+          },
+          comments: {
+            type: 'array',
+            description: 'Optional inline line-specific comments.',
+            items: {
+              type: 'object',
+              properties: {
+                path: { type: 'string' },
+                line: { type: 'number' },
+                body: { type: 'string' },
+                side: { type: 'string', enum: ['LEFT', 'RIGHT'] },
+                start_line: { type: 'number' },
+              },
+              required: ['path', 'line', 'body'],
+            },
+          },
+        },
+        required: ['pr_url', 'body'],
+      },
+    },
+    handler: async (
+      args: Record<string, unknown>,
+      services: ToolServices,
+    ): Promise<ToolResult> => {
+      const prUrl = args.pr_url as string | undefined;
+      const body = args.body as string | undefined;
+      const event = (args.event as string | undefined) ?? 'COMMENT';
+      const rawComments = (args.comments as InlineComment[] | undefined) ?? [];
+
+      if (!prUrl) return errorResult('pr_url is required for post_pr_review.');
+      if (!body) return errorResult('body is required for post_pr_review.');
+      if (!VALID_EVENTS.has(event)) {
+        return errorResult(
+          `Invalid event '${event}'. Must be one of APPROVE, REQUEST_CHANGES, COMMENT.`,
+        );
+      }
+
+      const resolved = await resolvePR(services, prUrl);
+      if ('content' in resolved && 'isError' in resolved) return resolved;
+      const { pr, github } = resolved as {
+        pr: { owner: string; repo: string; pull_number: number };
+        github: GitHubService;
+      };
+
+      const comments: InlineComment[] = rawComments.map((c) => ({
+        path: c.path,
+        line: c.line,
+        body: c.body,
+        side: c.side,
+        start_line: c.start_line,
+      }));
+
+      const review: ReviewInput = {
+        body,
+        event: event as ReviewInput['event'],
+        comments,
+      };
+
+      try {
+        const result = await github.createReview(
+          pr.owner,
+          pr.repo,
+          pr.pull_number,
+          review,
+        );
+        return jsonResult(result);
+      } catch (err) {
+        return errorResult((err as Error).message);
+      }
+    },
+  });
+}

--- a/refactor/src/tools/registry.ts
+++ b/refactor/src/tools/registry.ts
@@ -1,0 +1,73 @@
+/**
+ * Tool registry — typed catalogue of MCP tools available to the server.
+ *
+ * Each tool registers a `{ definition, handler }` entry. The server's
+ * `ListTools` handler iterates `toolDefinitions`; the `CallTool` handler
+ * looks up the entry in `getTool` and invokes the handler with the resolved
+ * service bundle.
+ *
+ * Keeping the registry a mutable singleton (rather than a frozen map) lets
+ * individual tool modules self-register at import time: the server imports
+ * `./tools/index.js` (which in turn imports each tool module) and the
+ * registry is populated as a side effect.
+ */
+
+import type {
+  ToolDefinition,
+  ToolResult,
+  ToolServices,
+} from '../types/index.js';
+
+/**
+ * Synchronous handler invoked by `CallTool` with the typed args object and
+ * the resolved service bundle. Handlers must:
+ *   - enforce the repo allowlist before any GitHub call;
+ *   - return a `ToolResult` envelope (`{ content: [{ type: 'text', text }] }`);
+ *   - set `isError: true` on user-facing errors (allowlist, bad args, etc.).
+ */
+export type ToolHandler = (
+  args: Record<string, unknown>,
+  services: ToolServices,
+) => Promise<ToolResult>;
+
+export interface ToolEntry {
+  definition: ToolDefinition;
+  handler: ToolHandler;
+}
+
+const registry = new Map<string, ToolEntry>();
+
+/**
+ * Ordered list of tool definitions registered so far.
+ * Reassign on each access so callers always see the current snapshot.
+ */
+export const toolDefinitions: ToolDefinition[] = [];
+
+/**
+ * Register a tool. Throws if a tool with the same name is already registered.
+ */
+export function registerTool(entry: ToolEntry): void {
+  if (registry.has(entry.definition.name)) {
+    throw new Error(
+      `Tool '${entry.definition.name}' is already registered`,
+    );
+  }
+  registry.set(entry.definition.name, entry);
+  toolDefinitions.push(entry.definition);
+}
+
+/**
+ * Look up a tool by name. Returns `undefined` when not found.
+ */
+export function getTool(name: string): ToolEntry | undefined {
+  return registry.get(name);
+}
+
+/**
+ * Clears every registered tool. Intended for tests that need an isolated
+ * registry; production code never calls this.
+ */
+export function resetRegistry(): void {
+  registry.clear();
+  toolDefinitions.length = 0;
+}

--- a/refactor/src/tools/shared.ts
+++ b/refactor/src/tools/shared.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared helpers used by all tool handlers.
+ *
+ * Centralizes:
+ *  - the repo-allowlist gate (called before ANY GitHub API request);
+ *  - construction of a GitHubService bound to the installation Octokit;
+ *  - JSON-to-ToolResult formatting.
+ */
+
+import { GitHubService } from '../services/github.js';
+import type {
+  PRRef,
+  ToolResult,
+  ToolServices,
+} from '../types/index.js';
+
+/** Build a ToolResult error envelope. */
+export function errorResult(message: string): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify({ error: message }) }],
+    isError: true,
+  };
+}
+
+/** Build a ToolResult success envelope around `data`. */
+export function jsonResult(data: unknown): ToolResult {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data, null, 2) }],
+  };
+}
+
+/**
+ * Enforce the repo allowlist. Returns an error result when the repo is not
+ * allowed; returns `null` otherwise so callers can early-return.
+ */
+export function enforceAllowlist(
+  services: ToolServices,
+  owner: string,
+  repo: string,
+): ToolResult | null {
+  if (!services.config.isRepoAllowed(owner, repo)) {
+    return errorResult(
+      `Repository '${owner}/${repo}' is not in the allowlist.`,
+    );
+  }
+  return null;
+}
+
+/**
+ * Construct a GitHubService bound to the installation Octokit for
+ * {owner, repo}. Assumes the caller has already enforced the allowlist.
+ */
+export async function buildGitHub(
+  services: ToolServices,
+  owner: string,
+  repo: string,
+): Promise<GitHubService> {
+  const octokit = await services.githubApp.getInstallationOctokit(
+    owner,
+    repo,
+  );
+
+  // Unit tests provide a GitHubService-shaped mock directly instead of an
+  // Octokit-shaped `{ rest: ... }` object. Accept either shape so handlers stay
+  // easy to test while production still wraps real installation Octokit.
+  if (octokit && typeof (octokit as { getPRDetails?: unknown }).getPRDetails === 'function') {
+    return octokit as GitHubService;
+  }
+
+  return new GitHubService(octokit as never);
+}
+
+/**
+ * Parse a PR URL, enforce the allowlist for the resolved repo, and build
+ * a GitHubService. Returns either a `ToolResult` (on parse/allowlist
+ * failure) or `{ pr, github }`.
+ */
+export async function resolvePR(
+  services: ToolServices,
+  pr_url: string,
+): Promise<ToolResult | { pr: PRRef; github: GitHubService }> {
+  let pr: PRRef;
+  try {
+    pr = new GitHubService({} as never).parsePRURL(pr_url);
+  } catch (err) {
+    return errorResult((err as Error).message);
+  }
+  const denied = enforceAllowlist(services, pr.owner, pr.repo);
+  if (denied) return denied;
+  const github = await buildGitHub(services, pr.owner, pr.repo);
+  return { pr, github };
+}

--- a/refactor/src/types/index.ts
+++ b/refactor/src/types/index.ts
@@ -174,6 +174,8 @@ export interface InlineComment {
   start_line?: number;
   /** Which side of the diff: LEFT (base) or RIGHT (head). */
   side?: 'LEFT' | 'RIGHT';
+  /** Optional starting side for multi-line comments. Required when start_line is set. */
+  start_side?: 'LEFT' | 'RIGHT';
 }
 
 /**

--- a/refactor/src/types/index.ts
+++ b/refactor/src/types/index.ts
@@ -1,0 +1,314 @@
+/**
+ * Shared domain types for the MCP review server.
+ *
+ * One responsibility per file is the rule across `src/`, but shared domain
+ * types live here so services and tools can reference them without circular
+ * imports.
+ */
+
+/**
+ * A reference to a GitHub Pull Request, parsed from a PR URL or assembled
+ * directly by the caller.
+ */
+export interface PRRef {
+  /** Repository owner (user or organization login). */
+  owner: string;
+  /** Repository name. */
+  repo: string;
+  /** Pull request number. */
+  pull_number: number;
+}
+
+/**
+ * A reference to a GitHub repository.
+ */
+export interface RepoRef {
+  owner: string;
+  repo: string;
+}
+
+/**
+ * A review strategy loaded from `refactor/strategies/*.md`.
+ *
+ * Frontmatter becomes metadata, the Markdown body becomes the prompt text
+ * returned to n8n's agent.
+ */
+export interface Strategy {
+  /** Strategy name; must match the catalog file basename. */
+  name: string;
+  /** Short human-readable description of what the strategy focuses on. */
+  description: string;
+  /** Optional trigger hints (e.g. `pr_with_secrets`). */
+  triggers?: string[];
+  /** Optional priority; lower number = higher priority. */
+  priority?: number;
+  /** The prompt body returned to the n8n agent. */
+  body: string;
+}
+
+/**
+ * Per-repo configuration read from `.github/review-config.yaml`.
+ */
+export interface RepoConfig {
+  /** Allowed/preferred strategy names from the catalog. */
+  strategies: string[];
+  /** Fallback strategy name when none is requested or none are listed. */
+  default?: string;
+}
+
+/**
+ * Result of resolving strategies for a repository.
+ */
+export interface ResolvedStrategies {
+  /** The matched strategies in catalog order. */
+  strategies: Strategy[];
+  /** A human-readable notice (fallback, missing config, etc.). */
+  notice?: string;
+}
+
+/**
+ * A file changed in a pull request, mirroring the legacy shape.
+ */
+export interface PRFile {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  /** Unified diff patch; may be omitted for binary/large files. */
+  patch?: string;
+  blob_url?: string;
+}
+
+/**
+ * Commit info embedded in PR details.
+ */
+export interface PRCommit {
+  sha: string;
+  message: string;
+  author: string;
+  date: string;
+}
+
+/**
+ * Existing review on a PR.
+ */
+export interface ExistingReview {
+  id: number;
+  user: string;
+  state: string;
+  body: string | null;
+  submitted_at: string | null;
+}
+
+/**
+ * Compact PR metadata returned by `get_pr_details`.
+ */
+export interface PRDetails {
+  pr: {
+    id: number;
+    number: number;
+    title: string;
+    body: string | null;
+    state: string;
+    author: string;
+    created_at: string;
+    updated_at: string;
+    base_branch: string;
+    head_branch: string;
+    mergeable: boolean | null;
+    additions: number;
+    deletions: number;
+    changed_files: number;
+  };
+  files: PRFile[];
+  commits: PRCommit[];
+  existing_reviews: ExistingReview[];
+  repository: {
+    owner: string;
+    repo: string;
+    full_name: string;
+  };
+}
+
+/**
+ * A file entry in a compare/diff-range result.
+ */
+export interface DiffFile {
+  filename: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  changes: number;
+  patch?: string;
+  blob_url?: string;
+}
+
+/**
+ * Result of `get_pr_diff_range`.
+ */
+export interface DiffRange {
+  /** Base commit SHA the comparison starts from. */
+  base_sha: string;
+  /** Head commit SHA the comparison ends at. */
+  head_sha: string;
+  /** Total commits in the range. */
+  total_commits: number;
+  /** Total files changed in the range. */
+  total_files: number;
+  /** Files with patches. */
+  files: DiffFile[];
+}
+
+/**
+ * An inline review comment to post on a PR.
+ */
+export interface InlineComment {
+  /** File path (relative to repo root). */
+  path: string;
+  /** Line number to comment on. */
+  line: number;
+  /** Comment body (Markdown). */
+  body: string;
+  /** Optional starting line for multi-line comments. */
+  start_line?: number;
+  /** Which side of the diff: LEFT (base) or RIGHT (head). */
+  side?: 'LEFT' | 'RIGHT';
+}
+
+/**
+ * A review to post on a PR.
+ */
+export interface ReviewInput {
+  /** Review body (Markdown). */
+  body: string;
+  /** Review event type. */
+  event?: 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
+  /** Inline line-specific comments. */
+  comments?: InlineComment[];
+}
+
+/**
+ * Result of posting a review.
+ */
+export interface ReviewResult {
+  success: boolean;
+  review_id: number;
+  review_url: string;
+}
+
+/**
+ * Repository info result.
+ */
+export interface RepoInfo {
+  owner: string;
+  repo: string;
+  full_name: string;
+  languages: Record<string, number>;
+  primary_language: string;
+  has_readme: boolean;
+  readme_content: string | null;
+}
+
+/**
+ * A text content block returned by MCP tool handlers.
+ */
+export interface TextContent {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * MCP tool result envelope (content blocks + isError flag).
+ */
+export interface ToolResult {
+  content: TextContent[];
+  isError?: boolean;
+}
+
+/**
+ * A JSON Schema for a tool's input parameters (MCP tool definition shape).
+ */
+export interface ToolInputSchema {
+  type: 'object';
+  properties?: Record<string, unknown>;
+  required?: string[];
+  [key: string]: unknown;
+}
+
+/**
+ * A registered MCP tool definition.
+ */
+export interface ToolDefinition {
+  name: string;
+  description: string;
+  inputSchema: ToolInputSchema;
+}
+
+/**
+ * Contract for the config service (implemented in `services/config.ts`).
+ */
+export interface IConfigService {
+  readonly githubAppId: string;
+  readonly githubAppPrivateKey: string;
+  readonly mcpApiSecret: string;
+  readonly port: number;
+  readonly maxPatchSize: number;
+  readonly maxFilesToReview: number;
+  readonly requestTimeout: number;
+  /** Returns true when no allowlist is set (allow all installed repos). */
+  isRepoAllowed(owner: string, repo: string): boolean;
+  /** Safe-to-log object with secrets masked. */
+  toDebugObject(): Record<string, string | number | boolean | undefined>;
+}
+
+/**
+ * Contract for the GitHub App auth module (implemented in `auth/github-app.ts`).
+ */
+export interface IGitHubAppAuth {
+  /** Returns an installation-scoped Octokit for {owner,repo}. */
+  getInstallationOctokit(owner: string, repo: string): Promise<unknown>;
+  /** Clears cached tokens (used in tests). */
+  clearCache(): void;
+}
+
+/**
+ * Contract for the GitHub Octokit wrapper (implemented in `services/github.ts`).
+ */
+export interface IGitHubService {
+  getPRDetails(pr_url: string): Promise<PRDetails>;
+  getPRFiles(pr_url: string, include_patch?: boolean): Promise<PRFile[]>;
+  getFileContent(owner: string, repo: string, path: string, ref?: string): Promise<string | null>;
+  getPRCommits(pr_url: string): Promise<PRCommit[]>;
+  getDiffRange(owner: string, repo: string, base_sha: string, head_sha: string): Promise<DiffRange>;
+  createReview(owner: string, repo: string, pull_number: number, review: ReviewInput): Promise<ReviewResult>;
+  getRepoInfo(owner: string, repo: string): Promise<RepoInfo>;
+  parsePRURL(url: string): PRRef;
+}
+
+/**
+ * Contract for the strategy service (implemented in `services/strategy.ts`).
+ */
+export interface IStrategyService {
+  /** All catalog strategies keyed by name. */
+  getCatalog(): Map<string, Strategy>;
+  /** Resolve strategies for a repo against its `.github/review-config.yaml`. */
+  resolveForRepo(
+    octokit: unknown,
+    owner: string,
+    repo: string,
+    requested?: string,
+  ): Promise<ResolvedStrategies>;
+}
+
+/**
+ * Shared service bundle passed to tool handlers.
+ */
+export interface ToolServices {
+  /** Resolved application configuration. */
+  config: IConfigService;
+  /** GitHub App token minter / installation Octokit factory. */
+  githubApp: IGitHubAppAuth;
+  /** Strategy catalog + repo-config resolver. */
+  strategy: IStrategyService;
+}

--- a/refactor/strategies/architecture.md
+++ b/refactor/strategies/architecture.md
@@ -1,0 +1,37 @@
+---
+name: architecture
+description: Architecture, SOLID, coupling/cohesion and design-pattern review
+triggers:
+  - large_changes
+  - new_modules
+  - refactors
+priority: 3
+---
+
+# Architecture & Design Review Strategy
+
+You are reviewing this PR for architecture and design quality. Focus on
+patterns, SOLID adherence, coupling/cohesion, scalability, maintainability.
+
+## What to check
+
+- **Design Patterns**: Are appropriate design patterns used consistently?
+- **SOLID Principles**: Single responsibility, open/closed, etc.
+- **Coupling and Cohesion**: Is the code properly decoupled with high cohesion?
+- **Scalability**: Will the changes scale with increased load or data?
+- **Maintainability**: How easy will it be to modify this code in the future?
+- **Naming**: Are variables, functions, and classes named clearly?
+- **Backward Compatibility**: Are breaking changes properly documented?
+- **Integration**: How well do the changes integrate with existing systems?
+
+## Review questions
+
+- Does a refactor improve quality without changing behavior?
+- Is the scope of refactoring appropriate (not too large, not too small)?
+- Does a new feature introduce avoidable technical debt?
+
+## Commenting guidance
+
+- Maximum of 3 inline comments per review request.
+- For each comment indicate this review was made by an AI agent.
+- Be constructive and specific; suggest alternatives when flagging issues.

--- a/refactor/strategies/full-review.md
+++ b/refactor/strategies/full-review.md
@@ -1,0 +1,71 @@
+---
+name: full-review
+description: Comprehensive multi-dimensional review (quality, architecture, security, performance, tests, functionality)
+priority: 5
+---
+
+# Pull Request Review Guidelines (Full Review)
+
+You are an automated bot helper reviewing a GitHub pull request. Review the
+code and provide a detailed analysis based on the following guidelines.
+
+Attempt to comment on the pull request for **critical** and **important**
+issues. Maximum of 3 comments per review request. Focus on unresolved
+comments and threads if asked to review again.
+
+## 1. Code Quality Assessment
+- Identify blocking issues, important issues, and minor improvements.
+- Categorize by type: security, performance, logic errors, style, etc.
+- Are adequate tests included or do existing tests need updates?
+
+## 2. Architecture and Design Review
+- **Design Patterns**: Are appropriate patterns used consistently?
+- **SOLID Principles**: Does the code adhere to SOLID?
+- **Coupling/Cohesion**: Properly decoupled with high cohesion?
+- **Scalability** and **Maintainability**.
+
+## 3. Code Standards and Best Practices
+- **Naming Conventions**, **Code Formatting**, **Documentation**.
+- **Dependencies**: Are new dependencies justified and secure?
+- **Git Practices**: Are commits atomic and well-described?
+
+## 4. Functional Analysis
+- **Requirements Fulfillment**, **Edge Cases**, **Error Handling**.
+- **User Experience** and **Backward Compatibility**.
+- **Integration** with existing systems.
+
+## 5. Security Considerations
+- **Input Validation**, **Auth/Authz**, **Data Protection**.
+- **SQL Injection**, **XSS Prevention**, **Dependency Vulnerabilities**.
+
+## 6. Performance Analysis
+- **Algorithm Efficiency**, **Database Queries**, **Caching**.
+- **Resource Usage**, **Network Calls**.
+
+## 7. Review Tone and Communication
+- Be constructive and specific; suggest alternatives.
+- Acknowledge good practices and improvements.
+- Ask questions to understand reasoning.
+- Focus on the code, not the person.
+
+## 8. Reviewer Checklist
+- Code compiles without warnings.
+- All tests pass; follows project conventions.
+- No obvious security vulnerabilities.
+- Performance impact acceptable; documentation updated.
+- Breaking changes clearly documented.
+- The change is minimal necessary to achieve the goal.
+
+## 9. Common Red Flags
+- Overly complex functions/classes.
+- Hardcoded values that should be configurable.
+- Missing error handling; inconsistent style.
+- Lack of tests for critical functionality.
+- Commented-out code without explanation.
+- Tight coupling between unrelated components.
+
+## 10. Commenting on the pull request
+- Check whether a similar discussion already exists before posting.
+- Prioritize actionable, helpful comments (critical, security, performance).
+- Maximum 3 comments per review request.
+- On each comment indicate this review was made by an AI agent.

--- a/refactor/strategies/minimal.md
+++ b/refactor/strategies/minimal.md
@@ -1,0 +1,30 @@
+---
+name: minimal
+description: Minimal, low-noise review covering only blockers and critical issues
+priority: 1
+---
+
+# Minimal Review Strategy
+
+You are performing a minimal, low-noise review. Report **only** blocking and
+critical issues so the reviewer's inbox stays signal-rich.
+
+## What to report
+
+- Bugs that break functionality or data integrity.
+- Security vulnerabilities that are exploitable now.
+- Data loss or corruption risks.
+- Missing tests for critical, newly added behavior.
+
+## What NOT to report (under minimal review)
+
+- Style, naming, formatting.
+- Minor refactors or nice-to-haves.
+- Documentation wording.
+- Theoretical or low-probability edge cases.
+
+## Commenting guidance
+
+- Maximum of 1 inline comment unless multiple distinct critical issues exist.
+- For each comment indicate this review was made by an AI agent.
+- If nothing critical is found, post a short approving summary instead.

--- a/refactor/strategies/performance.md
+++ b/refactor/strategies/performance.md
@@ -1,0 +1,34 @@
+---
+name: performance
+description: Performance and resource-efficiency focused review
+triggers:
+  - hot_paths
+  - database_changes
+  - large_diffs
+priority: 3
+---
+
+# Performance Review Strategy
+
+You are reviewing this PR for performance and resource efficiency. Focus on
+algorithmic efficiency, database access, caching, and resource usage.
+
+## What to check
+
+- **Algorithm Efficiency**: Are efficient algorithms and data structures used?
+  Avoid O(n^2) hot loops.
+- **Database Queries**: Are queries optimized? N+1 queries? Missing indexes?
+  Batching?
+- **Caching**: Is appropriate caching implemented where beneficial? Are cache
+  keys/tTLs reasonable?
+- **Resource Usage**: Are memory and CPU usage reasonable? Any unbounded
+  growth (leaks)?
+- **Network Calls**: Are API calls batched/debounced? Are timeous set?
+- **Loops**: Cache `.length` in tight loops; avoid repeated allocations.
+
+## Commenting guidance
+
+- Maximum of 3 inline comments per review request.
+- For each comment indicate this review was made by an AI agent.
+- Suggest concrete alternatives (e.g. `for (let i = 0, len = arr.length; ...)`).
+- Distinguish micro-optimizations from real bottlenecks.

--- a/refactor/strategies/security.md
+++ b/refactor/strategies/security.md
@@ -1,0 +1,37 @@
+---
+name: security
+description: Focused security vulnerability and input-validation review
+triggers:
+  - pr_with_secrets
+  - dependency_changes
+  - auth_or_security_files
+priority: 2
+---
+
+# Security Review Strategy
+
+You are reviewing this PR for security issues. Focus on input validation,
+authentication and authorization boundaries, data protection, and dependency
+safety.
+
+## What to check
+
+- **Input Validation**: Is user input properly validated and sanitized?
+- **Authentication/Authorization**: Are access controls correctly implemented?
+- **Data Protection**: Is sensitive data (tokens, keys, PII) properly handled
+  and never logged in plaintext?
+- **Injection**: SQL injection (parameterized queries?), command injection,
+  XSS (`innerHTML`/`document.write`?), path traversal.
+- **Secrets**: Hardcoded passwords, API keys, tokens, private keys.
+- **Dependency Vulnerabilities**: New third-party dependencies — are they
+  secure, licensed, and up to date? Any known CVEs?
+- **Insecure Randomness**: `Math.random()` for security-sensitive values.
+- **Dangerous Eval**: `eval()`, `exec()`, `setTimeout(string)`.
+
+## Commenting guidance
+
+- Maximum of 3 inline comments per review request.
+- For each comment indicate this review was made by an AI agent.
+- Prioritize critical and exploitable findings; surface clear reproduction
+  context.
+- Acknowledge good security practices when present.

--- a/refactor/strategies/strategies.load.test.ts
+++ b/refactor/strategies/strategies.load.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import * as path from 'node:path';
+import * as url from 'node:url';
+import { StrategyService } from '../src/services/strategy.js';
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const CATALOG = path.join(__dirname);
+
+describe('seeded strategy catalog', () => {
+  const svc = new StrategyService({ catalogDir: CATALOG });
+
+  it('loads all five seeded strategies', () => {
+    const names = [...svc.getCatalog().keys()].sort();
+    expect(names).toEqual(
+      ['architecture', 'full-review', 'minimal', 'performance', 'security'].sort(),
+    );
+  });
+
+  for (const name of [
+    'security',
+    'performance',
+    'architecture',
+    'full-review',
+    'minimal',
+  ]) {
+    it(`${name} has non-empty name, description, and body`, () => {
+      const s = svc.getCatalog().get(name);
+      expect(s).toBeDefined();
+      expect(s!.name.trim().length).toBeGreaterThan(0);
+      expect(s!.description.trim().length).toBeGreaterThan(0);
+      expect(s!.body.trim().length).toBeGreaterThan(0);
+    });
+  }
+});

--- a/refactor/tsconfig.json
+++ b/refactor/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": ".",
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitReturns": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "declaration": false,
+    "sourceMap": true
+  },
+  "include": ["src/**/*.ts", "strategies/**/*.md"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/refactor/vitest.config.ts
+++ b/refactor/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    setupFiles: ['./vitest.setup.ts'],
+  },
+});

--- a/refactor/vitest.setup.ts
+++ b/refactor/vitest.setup.ts
@@ -1,0 +1,6 @@
+/**
+ * Vitest setup — sets required env vars before any module is evaluated.
+ */
+process.env.GITHUB_APP_ID = '12345';
+process.env.GITHUB_APP_PRIVATE_KEY = '-----BEGIN RSA PRIVATE KEY-----\nFAKE\n-----END RSA PRIVATE KEY-----';
+process.env.MCP_API_SECRET = 'test-secret';


### PR DESCRIPTION
## Summary

Adds a new isolated `refactor/` TypeScript package for the GitHub review MCP server while leaving the legacy root implementation intact.

Key changes:

- Adds a model-agnostic, LLM-free MCP server over Streamable HTTP.
- Uses GitHub App installation authentication instead of PAT/Gemini-era assumptions.
- Adds file-driven review strategies under `refactor/strategies/*.md`.
- Resolves per-repo `.github/review-config.yaml` strategy config.
- Implements typed GitHub PR data tools, review posting, and data-only analysis tools.
- Adds header-secret auth, rate limiting, `/health`, and stateless per-request MCP transport handling.
- Adds integration tests, Docker packaging, env sample, setup docs, and a sample review config.

## Why

This creates the new n8n-oriented architecture discussed in the design: n8n owns orchestration, model choice, and reasoning; this MCP server is a pure capability backend that exposes GitHub data, strategy prompts, and review-posting actions.

The new package is intentionally placed under `refactor/` so the current server remains available and undeprecated.

## Implementation notes

- `refactor/src/app.ts` is the Express app factory and supports mocked service injection for integration tests.
- `refactor/src/server.ts` is the thin production entrypoint.
- The MCP transport uses a fresh stateless `Server` + `StreamableHTTPServerTransport` per POST to avoid reusing the SDK stateless transport across requests.
- `refactor/src/auth/github-app.ts` mints and caches GitHub App installation tokens.
- `refactor/src/services/strategy.ts` loads local strategy markdown and resolves repo-level config.
- `refactor/src/services/github.ts` wraps Octokit operations for PR details, files, commits, content, compare ranges, repo info, and review creation.
- `refactor/src/services/analysis.ts` ports legacy heuristic analysis as data-only logic.

## Validation

Ran locally:

```bash
cd refactor
pnpm typecheck
pnpm test
pnpm build
docker build -t github-review-mcp-refactor:test .
```

Results:

- Typecheck passed.
- Test suite passed: 62 tests across 9 files.
- Build passed.
- Docker image built successfully.
- Container health check returned HTTP 200 from `/health`.

## Deployment / setup docs

Added `refactor/README.md` covering:

- local development
- required environment variables
- GitHub App permissions and installation
- repo `.github/review-config.yaml`
- n8n MCP Client wiring
- Docker and Fly.io notes

## Scope

All code changes are under `refactor/` plus the progress checklist under `docs/superpowers/specs/`. The legacy root server is intentionally untouched.
